### PR TITLE
feat(ota): log when no firmware update is available

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -219,7 +219,7 @@ static void perform_update(nvs_handle_t handle, const char *repo_url, bool prere
 
     const char *tag_name = tag->valuestring;
     if (*current_version && !is_version_newer(current_version, tag_name)) {
-        ESP_LOGI(TAG, "Firmware up-to-date (%s)", current_version);
+        ESP_LOGI(TAG, "Geen update beschikbaar");
         cJSON_Delete(root);
         free(json);
         return;


### PR DESCRIPTION
## Summary
- log "Geen update beschikbaar" when firmware is already up to date

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_688dc922c5a883219ccc76868a9b07f4