### PR TITLE
fix(cmake): use json component instead of cJSON

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,7 +20,7 @@ idf_component_register(
         esp_http_client
         app_update
         mbedtls
-        cJSON
+        json
         http_parser
     EMBED_TXTFILES
         "content/index.html"


### PR DESCRIPTION
## Summary
- replace `cJSON` dependency with `json` component in `main/CMakeLists.txt`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de0428a508321bf58d29e088d8b19