### PR TITLE
Include esp_https_ota in main component dependencies

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -9,6 +9,8 @@ idf_component_register(
         "."
         "include"
         "content"
+    PRIV_REQUIRES
+        esp_https_ota
     REQUIRES
         freertos
         esp_wifi


### PR DESCRIPTION
## Summary
- add esp_https_ota to main component's private requirements so OTA headers resolve

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install idf-py` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_688de32171308321b6dcae80169bac9b