### PR TITLE
fix: support latest mbedtls API

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -9,9 +9,16 @@
 #include <esp_app_desc.h>
 #include <cJSON.h>
 #include <mbedtls/sha256.h>
+#include <mbedtls/version.h>
 #include <ctype.h>
 
 #define OTA_NAMESPACE "ota"
+
+#if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000
+#define mbedtls_sha256_starts_ret mbedtls_sha256_starts
+#define mbedtls_sha256_update_ret mbedtls_sha256_update
+#define mbedtls_sha256_finish_ret mbedtls_sha256_finish
+#endif
 
 static const char *TAG = "ota";
 


### PR DESCRIPTION
## Summary
- fix build failure by mapping deprecated mbedtls SHA-256 helpers to new API

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e0865962c83218933ba43ac3e82fa