### PR TITLE
Fix OTA URL truncation warning

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -225,10 +225,11 @@ static void perform_update(nvs_handle_t handle, const char *repo_url, bool prere
     char api_base[256];
     normalize_repo_api(repo_url, api_base, sizeof(api_base));
     char api_url[256];
-    if (prerelease) {
-        snprintf(api_url, sizeof(api_url), "%s/releases", api_base);
-    } else {
-        snprintf(api_url, sizeof(api_url), "%s/releases/latest", api_base);
+    strlcpy(api_url, api_base, sizeof(api_url));
+    const char *suffix = prerelease ? "/releases" : "/releases/latest";
+    if (strlcat(api_url, suffix, sizeof(api_url)) >= sizeof(api_url)) {
+        ESP_LOGE(TAG, "API URL truncated");
+        return;
     }
 
     char *json = http_get(api_url);


### PR DESCRIPTION
## Summary
- prevent release API URL truncation by building strings with `strlcpy`/`strlcat`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e09d9fb2c832188101b778aea70d0