### PR TITLE
refactor(ota): mark partition position const for image verify

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -40,7 +40,7 @@ static bool ota_partition_has_valid_firmware(void) {
     return false;
   }
   esp_image_metadata_t data;
-  esp_partition_pos_t pos = {
+  const esp_partition_pos_t pos = {
       .offset = part->address,
       .size = part->size,
   };


### PR DESCRIPTION
## Summary
- mark `esp_partition_pos_t` struct as const when verifying OTA partition

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f0cd1cc708321b63bf5789363bc78