### PR TITLE
Allow flexible OTA signature file names

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -595,13 +595,20 @@ static void perform_update(nvs_handle_t handle, const char *repo_url,
       if (cJSON_IsString(name) && cJSON_IsString(url)) {
         if (strcmp(name->valuestring, "main.bin") == 0) {
           strlcpy(fw_url, url->valuestring, sizeof(fw_url));
-        } else if (strcmp(name->valuestring, "main.bin.sig") == 0) {
+        } else if (strstr(name->valuestring, ".sig") != NULL) {
           strlcpy(sig_url, url->valuestring, sizeof(sig_url));
         }
       }
     }
   }
-  if (!fw_url[0] || !sig_url[0]) {
+  if (!sig_url[0]) {
+    cJSON_Delete(root);
+    free(json);
+    ESP_LOGE(TAG, "No .sig file found in GitHub release assets");
+    ota_in_progress = false;
+    return;
+  }
+  if (!fw_url[0]) {
     cJSON_Delete(root);
     free(json);
     ESP_LOGE(TAG, "Required assets not found in release");


### PR DESCRIPTION
## Summary
- support any `.sig` file name in GitHub release assets
- clarify error when no signature file is present

## Testing
- `idf.py build` *(fails: command not found)*
- `gcc -c main/ota.c` *(fails: ota.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890f1f574788321a92e7c0d4d11093d