### PR TITLE
Improve ESP-IDF version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp32-lifecycle-manager)
 
 idf_build_get_property(idf_version IDF_VERSION)
-if(idf_version VERSION_LESS "5.4.0")
-    message(FATAL_ERROR "ESP-IDF v5.4 or later is required.")
+
+# Controleer of de versie-informatie aanwezig is
+if(NOT idf_version OR idf_version VERSION_LESS "5.4.0")
+    message(FATAL_ERROR
+        "ESP-IDF v5.4.0 or later is required. Detected version: '${idf_version}'"
+    )
 endif()


### PR DESCRIPTION
## Summary
- Ensure CMake stops when ESP-IDF version is missing or older than 5.4.0
- Report detected version in failure message

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689368a70ef083218217ff77bbf17359