### PR TITLE
Add robust ESP-IDF version detection with env fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,21 @@ cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp32-lifecycle-manager)
 
+# Probeer eerste detectie via CMake-afhankelijkheid
 idf_build_get_property(idf_version IDF_VERSION)
 
-# Controleer of de versie-informatie aanwezig is
-if(NOT idf_version OR idf_version VERSION_LESS "5.4.0")
-    message(FATAL_ERROR
-        "ESP-IDF v5.4.0 or later is required. Detected version: '${idf_version}'"
-    )
+# Fallback naar omgevingsvariabele als leeg
+if(NOT idf_version)
+    set(idf_version "$ENV{IDF_VERSION}")
+endif()
+
+# Verdere controle
+if(NOT idf_version)
+    message(WARNING "Kon ESP‑IDF‑versie niet automatisch detecteren. Ga door zonder versiecheck.")
+else()
+    if(idf_version VERSION_LESS "5.4.0")
+        message(FATAL_ERROR
+            "ESP‑IDF v5.4.0 of later is vereist. Gedetecteerd: '${idf_version}'"
+        )
+    endif()
 endif()


### PR DESCRIPTION
## Summary
- Improve CMake version check to use IDF property with environment fallback and warning when version is missing

## Testing
- `docker pull espressif/idf:v5.4` *(fails: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936d1db9688321aec7fa7065b68565