### PR TITLE
Add ESP-IDF 5 auto-connect compatibility

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -33,6 +33,7 @@
 #include <freertos/semphr.h>
 
 #include <esp_wifi.h>
+#include <esp_idf_version.h>
 #include <esp_event.h>
 #include <esp_netif.h>
 #include <esp_system.h>
@@ -186,10 +187,15 @@ static void wifi_config_init_wifi(void) {
 
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
         esp_wifi_init(&cfg);
+        esp_wifi_set_mode(WIFI_MODE_STA);
         esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, wifi_event_handler, NULL);
         esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, wifi_event_handler, NULL);
         ESP_LOGI("wifi_config", "Starting WiFi...");
         esp_wifi_start();
+        safe_set_auto_connect(true);
+#if ESP_IDF_VERSION_MAJOR < 5
+        esp_wifi_connect();
+#endif
 
         wifi_inited = true;
 }

--- a/main/wifi_config_util.c
+++ b/main/wifi_config_util.c
@@ -25,10 +25,15 @@
 #include "esp_idf_version.h"
 #include "esp_wifi.h"
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0)
-#error "ESP-IDF v5.4 or higher is required"
-#endif
-
-esp_err_t safe_set_auto_connect(bool enable) {
+esp_err_t safe_set_auto_connect(bool enable)
+{
+#if ESP_IDF_VERSION_MAJOR < 5
         return esp_wifi_set_auto_connect(enable);
+#else
+        if (enable) {
+                return esp_wifi_connect();
+        } else {
+                return esp_wifi_disconnect();
+        }
+#endif
 }


### PR DESCRIPTION
## Summary
- handle removed `esp_wifi_set_auto_connect` in ESP-IDF 5 using version checks
- start Wi-Fi in station mode and trigger manual reconnect when needed

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893793b459c8321ae4cc6d08925d865