### PR TITLE
Ensure ESP-IDF 5.4 compatibility

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -123,7 +123,12 @@ static void on_wifi_ready(void) {
 void app_main(void) {
     ESP_LOGI(TAG, "Application start");
     ESP_LOGI(TAG, "Initializing NVS");
-    ESP_ERROR_CHECK(nvs_flash_init());
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
     ESP_LOGI(TAG, "NVS initialized");
     gpio_init();
     ESP_LOGI(TAG, "GPIO initialized");

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -180,15 +180,15 @@ static void wifi_config_init_wifi(void) {
         static bool wifi_inited = false;
         if (wifi_inited) return;
 
-        esp_netif_init();
-        esp_event_loop_create_default();
-        esp_netif_create_default_wifi_ap();
-        esp_netif_create_default_wifi_sta();
+        ESP_ERROR_CHECK(esp_netif_init());
+        ESP_ERROR_CHECK(esp_event_loop_create_default());
+        ESP_ERROR_CHECK(esp_netif_create_default_wifi_ap() ? ESP_OK : ESP_FAIL);
+        ESP_ERROR_CHECK(esp_netif_create_default_wifi_sta() ? ESP_OK : ESP_FAIL);
 
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-        esp_wifi_init(&cfg);
-        esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, wifi_event_handler, NULL);
-        esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, wifi_event_handler, NULL);
+        ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+        ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, wifi_event_handler, NULL));
+        ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, wifi_event_handler, NULL));
 
         wifi_inited = true;
 }

--- a/main/wifi_config_util.c
+++ b/main/wifi_config_util.c
@@ -22,18 +22,12 @@
  **/
 
 #include "esp_err.h"
-#include "esp_idf_version.h"
 #include "esp_wifi.h"
 
-esp_err_t safe_set_auto_connect(bool enable)
-{
-#if ESP_IDF_VERSION_MAJOR < 5
-        return esp_wifi_set_auto_connect(enable);
-#else
+esp_err_t safe_set_auto_connect(bool enable) {
         if (enable) {
                 return esp_wifi_connect();
         } else {
                 return esp_wifi_disconnect();
         }
-#endif
 }


### PR DESCRIPTION
## Summary
- Harden NVS initialization by handling flash version mismatch cases
- Simplify Wi-Fi auto-connect helper for ESP-IDF v5.4+ only
- Add error handling for Wi-Fi and event initialization routines

## Testing
- `idf.py --version` *(fails: command not found)*
- `pip install --user esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_6893845d6dc48321b55b843d0636456a