### PR TITLE
Ensure SoftAP advertises full WPA2 settings

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -873,6 +873,7 @@ static void wifi_config_softap_start() {
                                   {
                                       .required = false,
                                   },
+                              .sae_pwe_h2e = WPA3_SAE_PWE_UNSPECIFIED,
                               /* Use a shorter beacon interval for improved
                                  detection on some clients. */
                               .beacon_interval = 100,
@@ -884,6 +885,9 @@ static void wifi_config_softap_start() {
   if (context->password) {
     strncpy((char *)ap_cfg.ap.password, context->password,
             sizeof(ap_cfg.ap.password));
+    if (context->password[0] == '\0') {
+      ap_cfg.ap.authmode = WIFI_AUTH_OPEN;
+    }
   }
 
   /* Ensure both AP and STA configs are set before starting WiFi. */


### PR DESCRIPTION
## Summary
- add SAE PWE configuration to the SoftAP setup for standards-compliant WPA2 beacons
- set SoftAP auth mode to OPEN when password is empty for easier diagnostics

## Testing
- `idf.py build` *(fails: command not found)*
- `apt-get install -y gcc-xtensa-esp32-elf` *(fails: Unable to locate package)*
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689399b51e0c8321b42cda75cac2f59d