### PR TITLE
Replace deprecated Wi-Fi API and add OTA URL bounds check

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -590,7 +590,15 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
     }
   }
   if (!sig_url[0]) {
-    snprintf(sig_url, sizeof(sig_url), "%s.sig", fw_url);
+    if (strlen(fw_url) < sizeof(sig_url) - 4) {
+      snprintf(sig_url, sizeof(sig_url), "%s.sig", fw_url);
+    } else {
+      ESP_LOGE(TAG, "FW URL too long for signature URL buffer");
+      cJSON_Delete(root);
+      free(json);
+      ota_in_progress = false;
+      return false;
+    }
     ESP_LOGW(TAG, "No signature asset found; assuming %s", sig_url);
   }
 

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -923,7 +923,7 @@ static void wifi_config_monitor_callback(TimerHandle_t xTimer) {
     }
 
     wifi_config_softap_stop();
-    sdk_wifi_station_set_auto_connect(false);
+    esp_wifi_set_auto_connect(false);
 
     if (context->on_event)
       context->on_event(WIFI_CONFIG_CONNECTED);


### PR DESCRIPTION
## Summary
- replace `sdk_wifi_station_set_auto_connect` with `esp_wifi_set_auto_connect`
- guard against overflowing signature URL buffer during OTA update

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6894cafd07108321ab9ec6fee4980661