### PR TITLE
Handle ESP-IDF 5.4 API changes

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -590,9 +590,8 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
     }
   }
   if (!sig_url[0]) {
-    if (strlen(fw_url) < sizeof(sig_url) - 5) { // 4 for ".sig" + 1 for '\0'
-      snprintf(sig_url, sizeof(sig_url), "%s.sig", fw_url);
-    } else {
+    if (strlcpy(sig_url, fw_url, sizeof(sig_url)) >= sizeof(sig_url) ||
+        strlcat(sig_url, ".sig", sizeof(sig_url)) >= sizeof(sig_url)) {
       ESP_LOGE(TAG, "FW URL too long for signature URL buffer");
       cJSON_Delete(root);
       free(json);

--- a/main/wifi_config_util.c
+++ b/main/wifi_config_util.c
@@ -23,11 +23,19 @@
 
 #include "esp_err.h"
 #include "esp_wifi.h"
+#include "esp_idf_version.h"
 
 esp_err_t safe_set_auto_connect(bool enable) {
 #if CONFIG_ESP_WIFI_ENABLED
-    return esp_wifi_set_auto_connect(enable);
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 0)
+  return esp_wifi_set_auto_connect(enable);
 #else
-    return ESP_OK;
+  // esp_wifi_set_auto_connect was removed in ESP-IDF v5.4
+  (void)enable;
+  return ESP_OK;
+#endif
+#else
+  (void)enable;
+  return ESP_OK;
 #endif
 }


### PR DESCRIPTION
## Summary
- Guard wifi auto-connect helper against removal of `esp_wifi_set_auto_connect` in ESP-IDF v5.4
- Replace `snprintf` with safe string operations when constructing OTA signature URL

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d777650c8321956e100a3fae8316