### PR TITLE
Ensure OTA update runs on fresh devices

### DIFF
--- a/main/ota.c
+++ b/main/ota.c
@@ -493,7 +493,7 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
                            bool prerelease, const char *auth) {
   ESP_LOGI(TAG, "Checking repository %s (prerelease=%d)", repo_url, prerelease);
   ota_in_progress = true;
-  char current_version[64] = CURRENT_VERSION;
+  char current_version[64] = APP_VERSION;
   ESP_LOGI(TAG, "Build version %s", current_version);
   char *stored_version = nvs_get_string(handle, "current_version");
   if (stored_version) {
@@ -584,7 +584,9 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
   }
 
   ESP_LOGI(TAG, "Latest tag %s", tag_name);
-  if (!is_version_newer(current_version, tag_name)) {
+  if (strcmp(current_version, "0.0.0") == 0) {
+    ESP_LOGI(TAG, "No firmware version detected – performing initial OTA...");
+  } else if (!is_version_newer(current_version, tag_name)) {
     ESP_LOGI(TAG, "No newer firmware available");
     cJSON_Delete(root);
     free(json);

--- a/main/version.h
+++ b/main/version.h
@@ -1,2 +1,2 @@
 #pragma once
-#define CURRENT_VERSION "0.0.2"
+#define APP_VERSION "0.0.0"


### PR DESCRIPTION
## Summary
- default firmware version is now 0.0.0
- always perform OTA when no firmware version is detected

## Testing
- `idf.py --version` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found)*
- `pip install espressif-idf` *(fails: No matching distribution found)*
- `cmake -S . -B build` *(fails: include could not find requested file `/tools/cmake/project.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68962417b5088321b973a5408f5186ce