### PR TITLE
Improve OTA robustness and portal handling

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -29,3 +29,5 @@ idf_component_register(
 )
 
 target_add_binary_data(${COMPONENT_TARGET} "github_root_ca.pem" TEXT)
+
+target_compile_definitions(${COMPONENT_TARGET} PRIVATE KEEP_PORTAL_DURING_OTA=0)

--- a/main/form_urlencoded.c
+++ b/main/form_urlencoded.c
@@ -54,6 +54,8 @@ char *url_unescape(const char *buffer, size_t size) {
         }
 
         char *result = malloc(len+1);
+        if (!result)
+                return NULL;
         i = j = 0;
         while (i < size) {
                 if (buffer[i] == '+') {
@@ -76,6 +78,11 @@ char *url_unescape(const char *buffer, size_t size) {
 
 
 form_param_t *form_params_parse(const char *s) {
+        if (!s)
+                return NULL;
+        if (strlen(s) > 4096)
+                return NULL;
+
         form_param_t *params = NULL;
 
         int i = 0;
@@ -88,10 +95,19 @@ form_param_t *form_params_parse(const char *s) {
                 }
 
                 form_param_t *param = malloc(sizeof(form_param_t));
+                if (!param) {
+                        form_params_free(params);
+                        return NULL;
+                }
                 param->name = url_unescape(s+pos, i-pos);
                 param->value = NULL;
                 param->next = params;
                 params = param;
+
+                if (!param->name) {
+                        form_params_free(params);
+                        return NULL;
+                }
 
                 if (s[i] == '=') {
                         i++;
@@ -99,6 +115,10 @@ form_param_t *form_params_parse(const char *s) {
                         while (s[i] && s[i] != '&') i++;
                         if (i != pos) {
                                 param->value = url_unescape(s+pos, i-pos);
+                                if (!param->value) {
+                                        form_params_free(params);
+                                        return NULL;
+                                }
                         }
                 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -25,10 +25,12 @@
 #include "ota.h"
 #include <driver/gpio.h>
 #include <esp_log.h>
+#include <esp_sntp.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <nvs_flash.h>
 #include <stdio.h>
+#include <time.h>
 #include <wifi_config.h>
 
 // GPIO-definities
@@ -41,6 +43,33 @@ static const char *TAG = "main";
 bool led_on = false;
 
 void led_write(bool on) { gpio_set_level(LED_GPIO, on ? 1 : 0); }
+
+static bool s_time_ready(void) {
+  time_t now = 0;
+  struct tm tm_info = {0};
+  time(&now);
+  localtime_r(&now, &tm_info);
+  return (tm_info.tm_year + 1900) >= 2024;
+}
+
+static void sync_time(void) {
+  sntp_setoperatingmode(SNTP_OPMODE_POLL);
+  sntp_servermode_dhcp(1);
+  sntp_setservername(0, "pool.ntp.org");
+  sntp_init();
+
+  const int timeout_ms = 15000;
+  int waited = 0;
+  while (!s_time_ready() && waited < timeout_ms) {
+    vTaskDelay(pdMS_TO_TICKS(250));
+    waited += 250;
+  }
+  if (!s_time_ready()) {
+    ESP_LOGW("TIME", "SNTP timeout; ga toch door (TLS kan falen)");
+  } else {
+    ESP_LOGI("TIME", "Systeemtijd gesynchroniseerd");
+  }
+}
 
 void gpio_init() {
   ESP_LOGI(TAG, "Initializing GPIOs");
@@ -85,37 +114,33 @@ void factory_reset() {
 // Task button
 void button_task(void *pvParameter) {
   ESP_LOGI(TAG, "Button task started");
-  bool last_state = true;
+  TickType_t pressed_ts = 0;
+  bool was_pressed = false;
 
   while (1) {
-    bool current_state = gpio_get_level(BUTTON_GPIO);
-
-    if (last_state != current_state) {
-      ESP_LOGI(TAG, "Button state: %d", current_state);
+    bool current = (gpio_get_level(BUTTON_GPIO) == 0);
+    if (current && !was_pressed) {
+      was_pressed = true;
+      pressed_ts = xTaskGetTickCount();
+    } else if (!current && was_pressed) {
+      TickType_t held = xTaskGetTickCount() - pressed_ts;
+      was_pressed = false;
+      if (held >= pdMS_TO_TICKS(3000)) {
+        ESP_LOGW(TAG, "LONG PRESS -> FACTORY RESET");
+        factory_reset();
+      } else {
+        ESP_LOGI(TAG, "Short press ignored (safety)");
+      }
     }
-
-    // Detecteer overgang van HIGH naar LOW (knop ingedrukt)
-    if (last_state && !current_state) {
-      ESP_LOGW(TAG, "BUTTON PRESSED → RESETTING CONFIGURATION");
-      factory_reset();
-    }
-
-    last_state = current_state;
     vTaskDelay(pdMS_TO_TICKS(DEBOUNCE_TIME_MS));
   }
 }
 
-void ota_task(void *pvParameter) {
-  while (1) {
-    ESP_LOGI("OTA_TASK", "Checking for firmware updates...");
-    ota_start();
-    vTaskDelay(pdMS_TO_TICKS(3600000));
-  }
-}
-
 static void on_wifi_ready(void) {
-  ESP_LOGI("MAIN", "WiFi connected! Starting OTA task...");
-  xTaskCreate(ota_task, "ota_task", 8192, NULL, 5, NULL);
+  ESP_LOGI("MAIN", "WiFi connected, synchronizing time…");
+  sync_time();
+  ESP_LOGI("MAIN", "Starting OTA task…");
+  ota_start();
 }
 
 void app_main(void) {
@@ -131,7 +156,7 @@ void app_main(void) {
   ESP_LOGI(TAG, "NVS initialized");
   gpio_init();
   ESP_LOGI(TAG, "GPIO initialized");
-  if (xTaskCreate(button_task, "button_task", 2048, NULL, 10, NULL) == pdPASS) {
+  if (xTaskCreate(button_task, "button_task", 4096, NULL, 10, NULL) == pdPASS) {
     ESP_LOGI(TAG, "Button task created");
   } else {
     ESP_LOGE(TAG, "Failed to create button task");

--- a/main/ota.c
+++ b/main/ota.c
@@ -6,6 +6,7 @@
 #include <esp_http_client.h>
 #include <esp_idf_version.h>
 #include <esp_log.h>
+#include <esp_crt_bundle.h>
 #include <esp_ota_ops.h>
 #include <esp_partition.h>
 #include <freertos/FreeRTOS.h>
@@ -38,11 +39,6 @@ static const char *TAG = "ota";
 
 extern void led_write(bool on);
 
-extern const char github_root_ca_pem_start[]
-    asm("_binary_github_root_ca_pem_start");
-extern const char github_root_ca_pem_end[]
-    asm("_binary_github_root_ca_pem_end");
-
 volatile bool ota_in_progress = false;
 
 #define LEDC_TIMER LEDC_TIMER_0
@@ -52,6 +48,18 @@ volatile bool ota_in_progress = false;
 #define LEDC_FREQUENCY 5000
 
 static TaskHandle_t led_task_handle = NULL;
+
+static esp_err_t http_open_with_retry(esp_http_client_handle_t client) {
+  const int max_tries = 5;
+  int delay_ms = 500;
+  for (int i = 0; i < max_tries; i++) {
+    if (esp_http_client_open(client, 0) == ESP_OK)
+      return ESP_OK;
+    vTaskDelay(pdMS_TO_TICKS(delay_ms));
+    delay_ms = delay_ms * 2 > 8000 ? 8000 : delay_ms * 2;
+  }
+  return ESP_FAIL;
+}
 
 static void led_fade_task(void *pv) {
   int duty = 0;
@@ -96,7 +104,11 @@ static void ota_led_start(void) {
   };
   ledc_channel_config(&channel);
 
-  xTaskCreate(led_fade_task, "ota_led", 1024, NULL, 1, &led_task_handle);
+  if (xTaskCreate(led_fade_task, "ota_led", 1024, NULL, 1,
+                  &led_task_handle) != pdPASS) {
+    ESP_LOGE(TAG, "Failed to create LED fade task");
+    led_task_handle = NULL;
+  }
 }
 
 static void ota_led_stop(void) {
@@ -185,7 +197,7 @@ static char *http_get(const char *url, const char *auth, int *out_status) {
       .url = url,
       .timeout_ms = 15000,
       .transport_type = HTTP_TRANSPORT_OVER_SSL,
-      .cert_pem = github_root_ca_pem_start,
+      .crt_bundle_attach = esp_crt_bundle_attach,
       .skip_cert_common_name_check = false,
       .user_agent = "esp32-lcm",
       .disable_auto_redirect = false, // follow GitHub's 302 redirect to S3
@@ -196,6 +208,7 @@ static char *http_get(const char *url, const char *auth, int *out_status) {
     ESP_LOGE(TAG, "Failed to init HTTP client");
     return NULL;
   }
+  esp_http_client_set_header(client, "User-Agent", "esp32-lcm");
   esp_http_client_set_header(client, "Accept", "application/vnd.github+json");
   esp_http_client_set_header(client, "X-GitHub-Api-Version", "2022-11-28");
   if (auth && *auth) {
@@ -203,7 +216,7 @@ static char *http_get(const char *url, const char *auth, int *out_status) {
     snprintf(header, sizeof(header), "Bearer %s", auth);
     esp_http_client_set_header(client, "Authorization", header);
   }
-  if (esp_http_client_open(client, 0) != ESP_OK) {
+  if (http_open_with_retry(client) != ESP_OK) {
     ESP_LOGE(TAG, "Failed to open HTTP connection");
     esp_http_client_cleanup(client);
     return NULL;
@@ -251,7 +264,7 @@ static bool download_sig(const char *url, const char *auth, uint8_t *out_hash,
       .url = url,
       .timeout_ms = 15000,
       .transport_type = HTTP_TRANSPORT_OVER_SSL,
-      .cert_pem = github_root_ca_pem_start,
+      .crt_bundle_attach = esp_crt_bundle_attach,
       .skip_cert_common_name_check = false,
       .user_agent = "esp32-lcm",
       .disable_auto_redirect = false, // follow GitHub's 302 redirect to S3
@@ -262,6 +275,7 @@ static bool download_sig(const char *url, const char *auth, uint8_t *out_hash,
     ESP_LOGE(TAG, "Failed to init HTTP client");
     return false;
   }
+  esp_http_client_set_header(client, "User-Agent", "esp32-lcm");
   esp_http_client_set_header(client, "Accept", "application/octet-stream");
   esp_http_client_set_header(client, "X-GitHub-Api-Version", "2022-11-28");
   if (auth && *auth) {
@@ -269,7 +283,7 @@ static bool download_sig(const char *url, const char *auth, uint8_t *out_hash,
     snprintf(header, sizeof(header), "Bearer %s", auth);
     esp_http_client_set_header(client, "Authorization", header);
   }
-  if (esp_http_client_open(client, 0) != ESP_OK) {
+  if (http_open_with_retry(client) != ESP_OK) {
     ESP_LOGE(TAG, "Failed to open HTTP connection");
     esp_http_client_cleanup(client);
     return false;
@@ -330,7 +344,7 @@ static bool download_and_flash(const char *url, const uint8_t *expected_hash,
       .url = url,
       .timeout_ms = 15000,
       .transport_type = HTTP_TRANSPORT_OVER_SSL,
-      .cert_pem = github_root_ca_pem_start,
+      .crt_bundle_attach = esp_crt_bundle_attach,
       .skip_cert_common_name_check = false,
       .user_agent = "esp32-lcm",
       .disable_auto_redirect = false, // follow GitHub's 302 redirect to S3
@@ -343,6 +357,7 @@ static bool download_and_flash(const char *url, const uint8_t *expected_hash,
     ota_led_stop();
     return false;
   }
+  esp_http_client_set_header(client, "User-Agent", "esp32-lcm");
   esp_http_client_set_header(client, "Accept", "application/octet-stream");
   esp_http_client_set_header(client, "X-GitHub-Api-Version", "2022-11-28");
   if (auth && *auth) {
@@ -350,7 +365,7 @@ static bool download_and_flash(const char *url, const uint8_t *expected_hash,
     snprintf(header, sizeof(header), "Bearer %s", auth);
     esp_http_client_set_header(client, "Authorization", header);
   }
-  if (esp_http_client_open(client, 0) != ESP_OK) {
+  if (http_open_with_retry(client) != ESP_OK) {
     ESP_LOGE(TAG, "Failed to open HTTP connection");
     esp_http_client_cleanup(client);
     ota_led_stop();
@@ -501,6 +516,8 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
                          sizeof(current_version));
     ESP_LOGI(TAG, "Stored version %s", current_version);
     free(stored_version);
+  } else {
+    ESP_LOGI(TAG, "No stored firmware version found (initial run)");
   }
 
   char api_base[512];
@@ -732,5 +749,7 @@ static void ota_task(void *pv) {
 
 void ota_start(void) {
   ESP_LOGI(TAG, "Starting OTA task");
-  xTaskCreate(ota_task, "ota_task", 8192, NULL, 5, NULL);
+  if (xTaskCreate(ota_task, "ota_task", 8192, NULL, 5, NULL) != pdPASS) {
+    ESP_LOGE(TAG, "Failed to create OTA task");
+  }
 }

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -37,6 +37,7 @@
 #include <esp_idf_version.h>
 #include <esp_log.h>
 #include <esp_netif.h>
+#include <esp_netif_ip_addr.h>
 #include <esp_system.h>
 #include <esp_timer.h>
 #include <esp_wifi.h>
@@ -48,6 +49,10 @@
 #include "form_urlencoded.h"
 #include "ota.h"
 #include "wifi_config.h"
+
+#ifndef KEEP_PORTAL_DURING_OTA
+#define KEEP_PORTAL_DURING_OTA 0
+#endif
 
 enum {
   STATION_MODE = 1,
@@ -152,10 +157,21 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
   if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
     ESP_LOGI("wifi_config", "Connected to WiFi network");
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-    sta_got_ip = true;
-    ESP_LOGI("wifi_config", "WiFi is fully ready!");
-    if (wifi_ready_cb)
-      wifi_ready_cb();
+    esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (netif) {
+      esp_netif_ip_info_t ip_info;
+      if (esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
+        sta_got_ip = true;
+        ESP_LOGI("wifi_config", "WiFi is fully ready! IP: " IPSTR,
+                 IP2STR(&ip_info.ip));
+        if (wifi_ready_cb)
+          wifi_ready_cb();
+      } else {
+        ESP_LOGW("wifi_config", "Failed to get IP info");
+      }
+    } else {
+      ESP_LOGW("wifi_config", "STA netif handle is NULL");
+    }
   } else if (event_base == WIFI_EVENT &&
              event_id == WIFI_EVENT_STA_DISCONNECTED) {
     sta_got_ip = false;
@@ -452,6 +468,14 @@ static void wifi_config_server_on_settings(client_t *client) {
   client_send_chunk(client, "");
 }
 
+static void http_400(client_t *client, const char *msg) {
+  char buffer[256];
+  int len = snprintf(buffer, sizeof(buffer),
+                     "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+                     (int)strlen(msg), msg);
+  client_send(client, buffer, len);
+}
+
 static void wifi_config_server_on_settings_update(client_t *client) {
   DEBUG("Update settings, body = %s", client->body);
 
@@ -471,6 +495,26 @@ static void wifi_config_server_on_settings_update(client_t *client) {
     DEBUG("Invalid form data, redirecting to /settings");
     form_params_free(form);
     client_send_redirect(client, 302, "/settings");
+    return;
+  }
+
+  size_t ssid_len = strlen(ssid_param->value);
+  size_t password_len = password_param ? strlen(password_param->value) : 0;
+  size_t repo_len = repo_param ? strlen(repo_param->value) : 0;
+
+  if (ssid_len == 0 || ssid_len > 32) {
+    http_400(client, "Invalid SSID");
+    form_params_free(form);
+    return;
+  }
+  if ((password_len > 0 && password_len < 8) || password_len > 64) {
+    http_400(client, "Invalid password length");
+    form_params_free(form);
+    return;
+  }
+  if (!repo_param || repo_len == 0 || repo_len > 120) {
+    http_400(client, "Invalid repo URL");
+    form_params_free(form);
     return;
   }
 
@@ -750,8 +794,10 @@ static void http_task(void *arg) {
 }
 
 static void http_start() {
-  xTaskCreate(http_task, "wifi_config HTTP", 8192, NULL, 2,
-              &context->http_task_handle);
+  if (xTaskCreate(http_task, "wifi_config HTTP", 8192, NULL, 2,
+                  &context->http_task_handle) != pdPASS) {
+    ESP_LOGE("wifi_config", "Failed to create HTTP task");
+  }
 }
 
 static void http_stop() {
@@ -847,8 +893,10 @@ static void dns_task(void *arg) {
 }
 
 static void dns_start() {
-  xTaskCreate(dns_task, "wifi_config DNS", 4096, NULL, 2,
-              &context->dns_task_handle);
+  if (xTaskCreate(dns_task, "wifi_config DNS", 4096, NULL, 2,
+                  &context->dns_task_handle) != pdPASS) {
+    ESP_LOGE("wifi_config", "Failed to create DNS task");
+  }
 }
 
 static void dns_stop() {
@@ -892,7 +940,10 @@ static void wifi_config_softap_start() {
   wifi_networks_mutex = xSemaphoreCreateBinary();
   xSemaphoreGive(wifi_networks_mutex);
 
-  xTaskCreate(wifi_scan_task, "wifi_config scan", 4096, NULL, 2, NULL);
+  if (xTaskCreate(wifi_scan_task, "wifi_config scan", 4096, NULL, 2, NULL) !=
+      pdPASS) {
+    ESP_LOGE("wifi_config", "Failed to create WiFi scan task");
+  }
 
   dns_start();
   http_start();
@@ -913,8 +964,10 @@ static void wifi_config_monitor_callback(TimerHandle_t xTimer) {
     INFO("Connected to WiFi network");
 
     if (ota_in_progress) {
-      INFO("OTA in progress; keeping captive portal active");
-      return;
+      if (KEEP_PORTAL_DURING_OTA) {
+        INFO("OTA in progress; keeping captive portal active");
+        return;
+      }
     }
 
     wifi_config_softap_stop();


### PR DESCRIPTION
## Summary
- sync time via SNTP before performing OTA
- switch OTA HTTP connections to certificate bundle with retry/backoff
- validate configuration input and stop captive portal after WiFi connects

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fda817e483218416f0ccf91a6c1c