### PR TITLE
Fix SNTP DHCP API for ESP-IDF 5.4

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -54,7 +54,10 @@ static bool s_time_ready(void) {
 
 static void sync_time(void) {
   esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
-  esp_sntp_servermode_dhcp(1);
+  // In ESP-IDF 5.4+, the DHCP SNTP server configuration API no longer
+  // carries the esp_ prefix. Use the updated function to obtain the
+  // server address from the DHCP response.
+  sntp_servermode_dhcp(true);
   esp_sntp_setservername(0, "pool.ntp.org");
   esp_sntp_init();
 


### PR DESCRIPTION
## Summary
- switch deprecated `esp_sntp_servermode_dhcp` call to `sntp_servermode_dhcp` for IDF 5.4+

## Testing
- `idf.py build` *(fails: command not found)*
- `apt-get install -y esp-idf` *(fails: package not found)*
- `pip install esp-idf` *(fails: no matching distribution)*


------
https://chatgpt.com/codex/tasks/task_e_68971aab6f1483219614ba5fd5a1262c