### PR TITLE
Fix SNTP init, OTA request duplication, and WiFi scan gating

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -25,7 +25,7 @@
 #include "ota.h"
 #include <driver/gpio.h>
 #include <esp_log.h>
-#include <esp_sntp.h>
+#include "apps/esp_sntp.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <nvs_flash.h>
@@ -60,9 +60,6 @@ static bool s_time_ready(void) {
 }
 
 static void start_time_sync(void) {
-  if (esp_sntp_enabled()) {
-    esp_sntp_stop();
-  }
   esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
   // In ESP-IDF 5.4+, the DHCP SNTP server configuration API is
   // esp_sntp_servermode_dhcp(), which is only available when
@@ -154,6 +151,8 @@ void button_task(void *pvParameter) {
 
 static void on_got_ip(void) {
   ESP_LOGI("MAIN", "WiFi connected, synchronizing time…");
+  if (esp_sntp_enabled())
+    esp_sntp_stop();
   if (!sntp_started) {
     start_time_sync();
   }

--- a/main/ota.c
+++ b/main/ota.c
@@ -48,6 +48,7 @@ volatile bool ota_in_progress = false;
 #define LEDC_FREQUENCY 5000
 
 static TaskHandle_t led_task_handle = NULL;
+static TaskHandle_t ota_task_handle = NULL;
 
 static esp_err_t http_open_with_retry(esp_http_client_handle_t client) {
   const int max_tries = 5;
@@ -191,7 +192,9 @@ static void normalize_repo_api(const char *input, char *output, size_t len) {
   snprintf(output, len, "https://api.github.com/repos/%s", repo_part_limited);
 }
 
-static char *http_get(const char *url, const char *auth, int *out_status) {
+static char *http_get(const char *url, const char *auth, const char *etag,
+                      const char *last_modified, char **out_etag,
+                      char **out_last_modified, int *out_status) {
   ESP_LOGI(TAG, "HTTP GET: %s", url);
   esp_http_client_config_t config = {
       .url = url,
@@ -216,6 +219,10 @@ static char *http_get(const char *url, const char *auth, int *out_status) {
     snprintf(header, sizeof(header), "Bearer %s", auth);
     esp_http_client_set_header(client, "Authorization", header);
   }
+  if (etag && *etag)
+    esp_http_client_set_header(client, "If-None-Match", etag);
+  if (last_modified && *last_modified)
+    esp_http_client_set_header(client, "If-Modified-Since", last_modified);
   if (http_open_with_retry(client) != ESP_OK) {
     ESP_LOGE(TAG, "Failed to open HTTP connection");
     esp_http_client_cleanup(client);
@@ -225,6 +232,17 @@ static char *http_get(const char *url, const char *auth, int *out_status) {
   int content_length = esp_http_client_fetch_headers(client);
   if (out_status)
     *out_status = esp_http_client_get_status_code(client);
+  const char *resp_etag = esp_http_client_get_header(client, "ETag");
+  const char *resp_last_mod = esp_http_client_get_header(client, "Last-Modified");
+  if (out_etag && resp_etag)
+    *out_etag = strdup(resp_etag);
+  if (out_last_modified && resp_last_mod)
+    *out_last_modified = strdup(resp_last_mod);
+  if (out_status && *out_status == 304) {
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+    return NULL;
+  }
   if (out_status && *out_status != 200) {
     ESP_LOGE(TAG, "HTTP status %d", *out_status);
     esp_http_client_close(client);
@@ -532,13 +550,38 @@ static bool perform_update(nvs_handle_t handle, const char *repo_url,
   }
   ESP_LOGI(TAG, "GitHub API URL: %s", api_url);
 
+  char *etag = nvs_get_string(handle, "etag");
+  char *last_mod = nvs_get_string(handle, "last_modified");
+  char *new_etag = NULL;
+  char *new_last_mod = NULL;
   int status = 0;
-  char *json = http_get(api_url, auth, &status);
-  if (!json) {
-    ESP_LOGE(TAG, "Failed to fetch release info (status %d)", status);
+  char *json =
+      http_get(api_url, auth, etag, last_mod, &new_etag, &new_last_mod, &status);
+  free(etag);
+  free(last_mod);
+  if (status == 304) {
+    ESP_LOGI(TAG, "Release not modified since last check");
+    free(new_etag);
+    free(new_last_mod);
     ota_in_progress = false;
     return false;
   }
+  if (!json) {
+    ESP_LOGE(TAG, "Failed to fetch release info (status %d)", status);
+    free(new_etag);
+    free(new_last_mod);
+    ota_in_progress = false;
+    return false;
+  }
+  if (new_etag) {
+    nvs_set_str(handle, "etag", new_etag);
+    free(new_etag);
+  }
+  if (new_last_mod) {
+    nvs_set_str(handle, "last_modified", new_last_mod);
+    free(new_last_mod);
+  }
+  nvs_commit(handle);
   ESP_LOGI(TAG, "OTA: Received GitHub JSON:\n%s", json);
 
   cJSON *root = cJSON_Parse(json);
@@ -741,15 +784,20 @@ static void ota_task(void *pv) {
   vTaskDelay(pdMS_TO_TICKS(3000));
   ESP_LOGI(TAG, "Checking for firmware updates");
   ota_check_and_install();
-  ESP_LOGI(TAG, "Initial OTA check complete");
-  firmware_update();
   ESP_LOGI(TAG, "OTA task finished");
+  ota_task_handle = NULL;
   vTaskDelete(NULL);
 }
 
 void ota_start(void) {
   ESP_LOGI(TAG, "Starting OTA task");
-  if (xTaskCreate(ota_task, "ota_task", 8192, NULL, 5, NULL) != pdPASS) {
+  if (ota_task_handle) {
+    ESP_LOGW(TAG, "OTA task already running");
+    return;
+  }
+  if (xTaskCreate(ota_task, "ota_task", 8192, NULL, 5, &ota_task_handle) !=
+      pdPASS) {
     ESP_LOGE(TAG, "Failed to create OTA task");
+    ota_task_handle = NULL;
   }
 }

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -66,6 +66,7 @@ enum {
 
 static nvs_handle_t wifi_cfg_handle;
 static volatile bool sta_got_ip = false;
+static volatile bool sta_connecting = false;
 static void (*wifi_ready_cb)(void) = NULL;
 
 static void normalize_repo_url(const char *input, char *output, size_t len) {
@@ -156,12 +157,14 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
                                int32_t event_id, void *event_data) {
   if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
     ESP_LOGI("wifi_config", "Connected to WiFi network");
+    sta_connecting = false;
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
     esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
     if (netif) {
       esp_netif_ip_info_t ip_info;
       if (esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
         sta_got_ip = true;
+        sta_connecting = false;
         ESP_LOGI("wifi_config", "WiFi is fully ready! IP: " IPSTR,
                  IP2STR(&ip_info.ip));
         if (wifi_ready_cb)
@@ -175,6 +178,7 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
   } else if (event_base == WIFI_EVENT &&
              event_id == WIFI_EVENT_STA_DISCONNECTED) {
     sta_got_ip = false;
+    sta_connecting = false;
   }
 }
 
@@ -338,6 +342,12 @@ static void wifi_scan_task(void *arg) {
     if (sdk_wifi_get_opmode() != STATIONAP_MODE)
       break;
 
+    if (sta_connecting) {
+      ESP_LOGW("wifi_config", "STA is connecting, skipping scan");
+      vTaskDelay(pdMS_TO_TICKS(5000));
+      continue;
+    }
+
     /* Run blocking scan on STA interface while AP remains active. */
     wifi_scan_config_t config = {
         .ssid = NULL,
@@ -354,8 +364,14 @@ static void wifi_scan_task(void *arg) {
     };
     ESP_LOGI("wifi_config", "Scanning for networks...");
     esp_err_t scan_err = esp_wifi_scan_start(&config, true);
+    if (scan_err == ESP_ERR_WIFI_STATE) {
+      ESP_LOGW("wifi_config", "WiFi scan not allowed while STA connecting");
+      vTaskDelay(pdMS_TO_TICKS(5000));
+      continue;
+    }
     if (scan_err != ESP_OK) {
-      ESP_LOGE("wifi_config", "WiFi scan start failed: %s", esp_err_to_name(scan_err));
+      ESP_LOGE("wifi_config", "WiFi scan start failed: %s",
+               esp_err_to_name(scan_err));
       vTaskDelay(10000 / portTICK_PERIOD_MS);
       continue;
     }
@@ -1043,6 +1059,7 @@ static int wifi_config_station_connect() {
   ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &sta_config));
 
   ESP_LOGI("wifi_config", "WiFi: Connecting to SSID %s", wifi_ssid);
+  sta_connecting = true;
   ESP_ERROR_CHECK(esp_wifi_connect());
   safe_set_auto_connect(true);
 


### PR DESCRIPTION
## Summary
- Switch to `esp_sntp_*` APIs and guard SNTP init with one-shot flag
- Add conditional GitHub requests with ETag/Last-Modified caching
- Ensure OTA task runs once and Wi-Fi scans pause while STA connects

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689722cdd0b08321aca75eb90073e530