### PR TITLE
fix: use time-ready check

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -152,10 +152,13 @@ void button_task(void *pvParameter) {
 
 static void on_got_ip(void) {
   ESP_LOGI("MAIN", "WiFi connected, synchronizing time…");
-  if (esp_sntp_enabled())
-    esp_sntp_stop();
-  if (!sntp_started) {
-    start_time_sync();
+  if (!s_time_ready()) {
+    if (esp_sntp_enabled()) {
+      esp_sntp_stop();
+    }
+    if (!sntp_started) {
+      start_time_sync();
+    }
   }
   ESP_LOGI("MAIN", "Starting OTA task…");
   ota_start();


### PR DESCRIPTION
## Summary
- check time setup before starting SNTP sync to avoid unused function warning

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found for esp-idf)*

------
https://chatgpt.com/codex/tasks/task_e_689736fcda388321af83223d7551cb10