### PR TITLE
Fix signedness warning in WiFi body buffer

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -615,7 +615,7 @@ static int wifi_config_server_on_body(http_parser *parser, const char *data,
     client->body_length = 0;
     return -1;
   }
-  client->body = (char *)tmp;
+  client->body = (uint8_t *)tmp;
   memcpy(client->body + client->body_length, data, length);
   client->body_length += length;
   client->body[client->body_length] = 0;


### PR DESCRIPTION
## Summary
- Cast realloc result to `uint8_t*` to match body buffer type and avoid pointer-sign build error

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975ba894e083218ddd62fa9be9fac2