### PR TITLE
Declare ota_check_task prototype

### DIFF
--- a/components/esp32-wifi-bootstrap/src/wifi_config.c
+++ b/components/esp32-wifi-bootstrap/src/wifi_config.c
@@ -47,6 +47,8 @@
 #include "wifi_config.h"
 #include "form_urlencoded.h"
 
+static void ota_check_task(void *arg);
+
 enum {
         STATION_MODE = 1,
         SOFTAP_MODE = 2,


### PR DESCRIPTION
## Summary
- declare ota_check_task prototype in wifi_config.c to fix build

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06b094e3c8321a46fcb173b3beb4a