### PR TITLE
Add DRD count and Wi-Fi reset on repeated power cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Deze bundel bevat een gepatchte versie die buildt met ESP-IDF 5.4. Belangrijkste
 - **lcm32/portal.c**: misleidende-indentation opgelost (Werror).
 - **wifi_config.c**: forward declaration `static void ota_check_task(void* arg);` toegevoegd, zodat calls compileren.
 
+LCM32 detecteert korte power-cycles om recovery-acties mogelijk te maken. Twee snelle herstarts openen de captive portal; acht of meer wissen de opgeslagen Wi-Fi-instellingen.
+
 ## Bouwen (Docker, aanbevolen)
 
 ```bash

--- a/components/lcm32/drd.c
+++ b/components/lcm32/drd.c
@@ -30,3 +30,7 @@ bool lcm32_drd_was_triggered(void) {
              (uint32_t)boot_counter, (uint32_t)s_window_ms, triggered ? "TRIGGERED" : "no");
     return triggered;
 }
+
+uint32_t lcm32_drd_get_count(void) {
+    return boot_counter;
+}

--- a/components/lcm32/include/drd.h
+++ b/components/lcm32/include/drd.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 void lcm32_drd_set_window_ms(uint32_t window_ms);
 bool lcm32_drd_was_triggered(void);
+uint32_t lcm32_drd_get_count(void);
 #ifdef __cplusplus
 }
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -1,10 +1,10 @@
-\
 #include "wifi_config.h"
 #include "lcm32.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_wifi.h"
 #include "esp_netif.h"
+#include "esp_system.h"
 #include "nvs_flash.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,6 +25,13 @@ void app_main(void) {
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
     lcm32_init();
+
+    uint32_t drd = lcm32_drd_get_count();
+    if (drd >= 8) {
+        ESP_LOGW(TAG, "Erasing Wi-Fi credentials (DRD count=%u)", drd);
+        wifi_config_reset();
+        esp_restart();
+    }
 
     // inject OTA fields into captive UI
     wifi_config_set_custom_html(


### PR DESCRIPTION
## Summary
- expose double reset detection counter for advanced recovery workflows
- erase stored Wi-Fi credentials after eight rapid reboots
- document power-cycle based recovery behavior in README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06eeb2d74832186b919857d6aef39