### PR TITLE
Include form URL parser in build

### DIFF
--- a/components/esp32-wifi-bootstrap/CMakeLists.txt
+++ b/components/esp32-wifi-bootstrap/CMakeLists.txt
@@ -4,6 +4,7 @@ idf_component_register(
         "src/wifi_config.c"
         "src/safe_auto_connect.c"
         "src/ota_stub.c"
+        "src/form_urlencoded.c"
     INCLUDE_DIRS
         "include" "content" "src"
     PRIV_REQUIRES


### PR DESCRIPTION
## Summary
- Fix undefined references to form parsing helpers by compiling `form_urlencoded.c`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0744291a483218244a6c704d5b3b6