### PR TITLE
Add minimal ESP-IDF project structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,3 @@
 cmake_minimum_required(VERSION 3.16)
-
-# Include the component build system from ESP-IDF so that the
-# idf_component_register macro is available when building this
-# repository as a standalone component.
-include($ENV{IDF_PATH}/tools/cmake/component.cmake)
-
-idf_component_register(
-    SRCS "src/wifi_config.c" "src/form_urlencoded.c" "src/wifi_config_util.c" "src/github_update.c"
-    INCLUDE_DIRS "include" "content"
-    PRIV_INCLUDE_DIRS "src"
-    PRIV_REQUIRES esp_wifi esp_event esp_netif nvs_flash esp_timer http_parser esp_https_ota esp_http_client mbedtls json
-)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32-lifecycle-manager)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,7 @@
+idf_component_register(
+    SRCS "app_main.c" "../src/wifi_config.c" "../src/form_urlencoded.c" "../src/wifi_config_util.c" "../src/github_update.c"
+    INCLUDE_DIRS "../include" "../content"
+    PRIV_INCLUDE_DIRS "../src"
+    PRIV_REQUIRES esp_wifi esp_event esp_netif nvs_flash esp_timer http_parser esp_https_ota esp_http_client mbedtls json
+    EMBED_FILES "../content/index.html"
+)

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -1,0 +1,3 @@
+void app_main(void) {
+    // Application entry point
+}

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -259,8 +259,8 @@ static void client_send(client_t *client, const char *payload, size_t payload_si
 }
 static void client_send_index(client_t *client) {
         ESP_LOGI("wifi_config", "Serving captive portal response");
-        extern const uint8_t index_html_start[] asm ("_binary_index_html_start");
-        extern const uint8_t index_html_end[] asm ("_binary_index_html_end");
+        extern const uint8_t content_index_html_start[] asm ("_binary_content_index_html_start");
+        extern const uint8_t content_index_html_end[] asm ("_binary_content_index_html_end");
 
         const char *header =
                 "HTTP/1.1 200 OK\r\n"
@@ -270,7 +270,7 @@ static void client_send_index(client_t *client) {
                 "\r\n";
 
         client_send(client, header, strlen(header));
-        client_send(client, (const char *)index_html_start, index_html_end - index_html_start);
+        client_send(client, (const char *)content_index_html_start, content_index_html_end - content_index_html_start);
 }
 
 


### PR DESCRIPTION
## Summary
- convert repository into an ESP-IDF project with standard `project.cmake`
- add `main` component registering existing sources and embedding index.html
- adjust wifi_config to use new embedded index.html symbols and provide stub `app_main`

## Testing
- `idf.py reconfigure`

------
https://chatgpt.com/codex/tasks/task_e_68ab2ce261b483219180a39bc8e8457c