### PR TITLE
Handle long redirect headers during signature download

### DIFF
--- a/main/github_update.c
+++ b/main/github_update.c
@@ -68,7 +68,9 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
     esp_http_client_config_t cfg = {
         .url = url,
         .crt_bundle_attach = esp_crt_bundle_attach,
-        .user_agent = "esp32-ota"
+        .user_agent = "esp32-ota",
+        // GitHub release assets use redirects with very long Location headers
+        .buffer_size = 2048,
     };
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
     if (!client) {


### PR DESCRIPTION
## Summary
- enlarge esp_http_client buffer to follow GitHub release redirects

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c1f979483218e6010ebea24771e