### PR TITLE
Fix empty if-body warning in WiFi configuration

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -970,8 +970,9 @@ static int wifi_config_station_connect() {
         }
 
         INFO("Connecting to %s", wifi_ssid);
-        if (wifi_password)
+        if (wifi_password) {
                 DEBUG("Using password of length %d", (int)strlen(wifi_password));
+        }
 
         wifi_config_t sta_config;
         memset(&sta_config, 0, sizeof(sta_config));


### PR DESCRIPTION
## Summary
- wrap debug statement inside braces to avoid empty `if` body when password is defined

## Testing
- `idf.py build`

------
https://chatgpt.com/codex/tasks/task_e_68bda62d24348321bb02822a26ba714d