### PR TITLE
Increase wifi ready task stack size

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -1031,12 +1031,13 @@ void wifi_config_start() {
         }
 }
 
-#define WIFI_READY_TASK_STACK_SIZE 4096
+#define WIFI_READY_TASK_STACK_SIZE 8192
 #define WIFI_READY_TASK_PRIORITY 5
 
 static void wifi_config_on_wifi_ready_task(void *pvParameter) {
         void (*callback)() = pvParameter;
         callback();
+        INFO("wifi_ready stack high water mark: %u", uxTaskGetStackHighWaterMark(NULL));
         vTaskDelete(NULL);
 }
 


### PR DESCRIPTION
## Summary
- increase wifi_ready task stack size to 8192
- log stack high water mark after wifi ready callback

## Testing
- `idf.py build`

------
https://chatgpt.com/codex/tasks/task_e_68bdb9ceed9883218fb91860ab1b542f