### PR TITLE
Handle long GitHub redirects by enlarging HTTP client buffers

### DIFF
--- a/main/github_update.c
+++ b/main/github_update.c
@@ -72,7 +72,8 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
         // GitHub release assets use redirects with extremely long Location headers
         // (currently >5k and sometimes exceeding 8k), so give the HTTP client a
         // generously sized buffer to ensure the Location header fits entirely.
-        .buffer_size = 16384,
+        .buffer_size = 32768,
+        .buffer_size_tx = 32768,
     };
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
     if (!client) {


### PR DESCRIPTION
## Summary
- increase esp_http_client header and TX buffers to 32KB when downloading signatures to handle large redirect headers

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68bee9c246588321b45d04ec3f1bcd49