### PR TITLE
Simplify firmware signing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
 # esp32-lifecycle-manager
 
-## Signing and uploading firmware
+## Signing firmware
 
-Use `sign_and_upload_release.py` to create a release on GitHub and upload a
-firmware image along with its signature. The script signs the firmware using
-an ECDSA or RSA private key that matches the public key embedded in the
-device.
+Use `sign_and_upload_release.py` to sign the firmware binary located at
+`build/main.bin`. The script writes the signature to `build/main.bin.sig` using
+an ECDSA or RSA private key that matches the public key embedded in the device.
 
 ```bash
-python3 sign_and_upload_release.py \
-    --owner <github-user> \
-    --repo <repository> \
-    --tag v1.0.0 \
-    --firmware build/main.bin \
-    --key ota_private_key.pem
+python3 sign_and_upload_release.py --key ota_private_key.pem
 ```
 
-The script generates `build/main.bin.sig` (~64–72 bytes for ECDSA or 256 bytes
-for RSA) and uploads both files to the release specified by `--tag`.
+The generated signature is roughly 64–72 bytes for ECDSA or 256 bytes for RSA
+keys.

--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python3
-"""Sign the firmware at ``build/main.bin`` and upload it plus its signature to a
-GitHub release.
+"""Sign the firmware at ``build/main.bin`` and generate ``build/main.bin.sig``.
 
 This script generates an ECDSA or RSA signature for the firmware binary located
 in the ``build`` directory using a private key that matches the public key
-embedded on the ESP32 device. The firmware and its signature are then uploaded
-as assets to a GitHub release using the GitHub REST API.
+embedded on the ESP32 device. The resulting signature is written next to the
+firmware image.
 """
 import argparse
 import hashlib
-import os
 import sys
 from pathlib import Path
 
-import json
-import urllib.error
-import urllib.parse
-import urllib.request
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives import serialization
@@ -56,79 +50,10 @@ def sign_firmware(fw_path: Path, key_path: Path) -> bytes:
     return signature
 
 
-class _Response:
-    def __init__(self, status_code: int, data: bytes, headers):
-        self.status_code = status_code
-        self.data = data
-        self.headers = headers
-
-    def json(self):
-        return json.loads(self.data.decode())
-
-
-def github_request(method: str, url: str, token: str, **kwargs):
-    params = kwargs.pop('params', None)
-    data = kwargs.pop('data', None)
-    json_data = kwargs.pop('json', None)
-    headers = kwargs.pop('headers', {})
-
-    if params:
-        url = f"{url}?{urllib.parse.urlencode(params)}"
-
-    if json_data is not None:
-        data = json.dumps(json_data).encode()
-        headers.setdefault('Content-Type', 'application/json')
-
-    headers['Authorization'] = f'token {token}'
-    headers.setdefault('Accept', 'application/vnd.github+json')
-
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
-
-    try:
-        with urllib.request.urlopen(req) as resp:
-            return _Response(resp.status, resp.read(), resp.headers)
-    except urllib.error.HTTPError as e:
-        return _Response(e.code, e.read(), e.headers)
-
-
-def get_or_create_release(owner: str, repo: str, tag: str, token: str) -> dict:
-    url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
-    r = github_request('GET', url, token)
-    if r.status_code == 200:
-        return r.json()
-    if r.status_code != 404:
-        raise RuntimeError(f"GitHub API error {r.status_code}: {r.data.decode()}")
-
-    # Create release if it does not exist
-    url = f"https://api.github.com/repos/{owner}/{repo}/releases"
-    data = {"tag_name": tag, "name": tag, "draft": False}
-    r = github_request('POST', url, token, json=data)
-    if r.status_code >= 400:
-        raise RuntimeError(f"GitHub API error {r.status_code}: {r.data.decode()}")
-    return r.json()
-
-
-def upload_asset(upload_url: str, file_path: Path, token: str):
-    upload_url = upload_url.split('{')[0]
-    params = {'name': file_path.name}
-    with file_path.open('rb') as f:
-        data = f.read()
-    headers = {'Content-Type': 'application/octet-stream'}
-    github_request('POST', upload_url, token, params=params, data=data, headers=headers)
-
-
 def main():
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument('--owner', required=True, help='GitHub repository owner')
-    p.add_argument('--repo', required=True, help='GitHub repository name')
-    p.add_argument('--tag', required=True, help='Release tag to create/update')
     p.add_argument('--key', required=True, type=Path, help='Path to private key (PEM)')
-    p.add_argument('--token', default=os.getenv('GITHUB_TOKEN'), help='GitHub token')
     args = p.parse_args()
-
-    if not args.token:
-        print('GitHub token must be provided via --token or GITHUB_TOKEN env var', file=sys.stderr)
-        return 1
 
     fw_path = Path('build/main.bin')
     if not fw_path.exists():
@@ -140,11 +65,7 @@ def main():
     with sig_path.open('wb') as f:
         f.write(signature)
 
-    release = get_or_create_release(args.owner, args.repo, args.tag, args.token)
-    upload_url = release['upload_url']
-    upload_asset(upload_url, fw_path, args.token)
-    upload_asset(upload_url, sig_path, args.token)
-    print(f"Uploaded {fw_path.name} and {sig_path.name} to release {args.tag}")
+    print(f"Generated {sig_path} from {fw_path}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Simplify signing script to only generate `build/main.bin.sig`
- Update README with new signing instructions

## Testing
- `python -m py_compile sign_and_upload_release.py`
- `python sign_and_upload_release.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bf17de979883219f58a944a62d12f5