### PR TITLE
chore: rotate OTA public key

### DIFF
--- a/main/ota_pubkey.c
+++ b/main/ota_pubkey.c
@@ -2,7 +2,7 @@
 
 const unsigned char ota_pubkey_pem[] =
 "-----BEGIN PUBLIC KEY-----\n"
-"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFNjyMmUCIFv3/WNEsihmvLIvqoho\n"
-"lhTyZ9o/cUGPyF6ftkX8kWQ8mERYw6y5FLNvba+QhHD1K33QOijM086HEg==\n"
+"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdvNFFIe+YXpUxiwFYlWAy3M3t6Sa\n"
+"BP6750XmINFU950HVj8YfJIa/ILfYQKMxiCrhiyzcz09kkRKY8iW8zrfhQ==\n"
 "-----END PUBLIC KEY-----\n";
 const size_t ota_pubkey_pem_len = sizeof(ota_pubkey_pem);


### PR DESCRIPTION
## Summary
- rotate ECDSA key by updating embedded public key for OTA validation

## Testing
- `idf.py build`
- `python3 sign_and_upload_release.py --key private_key.pem` *(succeeds locally, but assets not uploaded due to missing GitHub release credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c05582246c8321bb0b0a5c3adedef2