### PR TITLE
Ensure OTA signatures use device public key

### DIFF
--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -15,8 +15,9 @@ import os
 import sys
 from pathlib import Path
 
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa, utils
 from cryptography.hazmat.primitives import serialization
 
 
@@ -26,9 +27,14 @@ def load_private_key(path: Path):
     return serialization.load_pem_private_key(data, password=None)
 
 
-def sign_firmware(fw_path: Path, key_path: Path) -> bytes:
-    """Return raw binary signature of the firmware image."""
-    key = load_private_key(key_path)
+def load_public_key(path: Path):
+    with path.open('rb') as f:
+        data = f.read()
+    return serialization.load_pem_public_key(data)
+
+
+def sign_firmware(fw_path: Path, key) -> tuple[bytes, bytes]:
+    """Return (digest, raw signature) of the firmware image."""
 
     with fw_path.open('rb') as f:
         firmware = f.read()
@@ -39,10 +45,10 @@ def sign_firmware(fw_path: Path, key_path: Path) -> bytes:
         signature = key.sign(
             digest,
             padding.PKCS1v15(),
-            hashes.SHA256(),
+            utils.Prehashed(hashes.SHA256()),
         )
     elif isinstance(key, ec.EllipticCurvePrivateKey):
-        signature = key.sign(digest, ec.ECDSA(hashes.SHA256()))
+        signature = key.sign(digest, ec.ECDSA(utils.Prehashed(hashes.SHA256())))
     else:
         raise ValueError("Unsupported key type")
 
@@ -51,12 +57,13 @@ def sign_firmware(fw_path: Path, key_path: Path) -> bytes:
         raise ValueError(
             f"Unexpected signature length {sig_len} bytes; expected 64–72 or 256"
         )
-    return signature
+    return digest, signature
 
 
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--key', type=Path, help='Path to private key (PEM)')
+    p.add_argument('--pubkey', type=Path, help='Path to public key (PEM) for verification')
     args = p.parse_args()
 
     key_path = args.key or os.environ.get('OTA_PRIVATE_KEY')
@@ -79,15 +86,57 @@ def main():
                 )
             print(f'Generated new private key at {key_path}', file=sys.stderr)
 
+    pubkey_path = args.pubkey or os.environ.get('OTA_PUBLIC_KEY')
+    if pubkey_path:
+        pubkey_path = Path(pubkey_path)
+        if not pubkey_path.exists():
+            print(f'Public key {pubkey_path} not found', file=sys.stderr)
+            return 1
+        pubkey = load_public_key(pubkey_path)
+    else:
+        pubkey = None
+
     fw_path = Path('build/main.bin')
     if not fw_path.exists():
         print('Firmware binary build/main.bin not found', file=sys.stderr)
         return 1
 
-    signature = sign_firmware(fw_path, key_path)
+    key = load_private_key(key_path)
+    digest, signature = sign_firmware(fw_path, key)
+
     sig_path = fw_path.with_suffix(fw_path.suffix + '.sig')
     with sig_path.open('wb') as f:
         f.write(signature)
+
+    if pubkey:
+        derived = key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        expected = pubkey.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        if derived != expected:
+            print('Private key does not match provided public key', file=sys.stderr)
+            return 1
+        try:
+            if isinstance(pubkey, rsa.RSAPublicKey):
+                pubkey.verify(
+                    signature,
+                    digest,
+                    padding.PKCS1v15(),
+                    utils.Prehashed(hashes.SHA256()),
+                )
+            else:
+                pubkey.verify(
+                    signature,
+                    digest,
+                    ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+                )
+        except InvalidSignature:
+            print('Signature verification failed', file=sys.stderr)
+            return 1
 
     print(json.dumps({'signature_path': str(sig_path)}))
     return 0


### PR DESCRIPTION
## Summary
- sign firmware with a single SHA256 digest and prehashed ECDSA/RSA operations
- add optional `--pubkey` argument and verify that the private key, public key and signature all match

## Testing
- `python3 -m py_compile sign_and_upload_release.py`
- `python3 sign_and_upload_release.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c19b35004883219b9dcb853425493b