### PR TITLE
Ensure private key matches OTA pubkey and validate signatures

### DIFF
--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -4,9 +4,13 @@
 This utility searches for ``build/main.bin`` and, when found, generates a
 ``build/main.bin.sig`` using a private key. The key is read from the ``--key``
 argument or the ``OTA_PRIVATE_KEY`` environment variable. If neither is
-provided, a ``private_key.pem`` in the current directory is used, generating
-one if necessary. Upon success a JSON object describing the signature file is
-written to stdout, which can be consumed by GitHub Actions or the GitHub API.
+provided, ``private_key.pem`` in the current directory is used. The key must
+already exist – one will not be generated automatically – to prevent signing
+with a key that doesn't match the device firmware. The signature is verified
+against a public key loaded from ``--pubkey``, ``ota_pubkey.pem`` or
+``main/ota_pubkey.c``; if none are found a built-in default is used. Upon
+success a JSON object describing the signature file is written to stdout, which
+can be consumed by GitHub Actions or the GitHub API.
 """
 import argparse
 import hashlib
@@ -21,6 +25,13 @@ from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa, utils
 from cryptography.hazmat.primitives import serialization
 
 
+DEFAULT_PUBLIC_KEY_PEM = b"""-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdvNFFIe+YXpUxiwFYlWAy3M3t6Sa
+BP6750XmINFU950HVj8YfJIa/ILfYQKMxiCrhiyzcz09kkRKY8iW8zrfhQ==
+-----END PUBLIC KEY-----
+"""
+
+
 def load_private_key(path: Path):
     with path.open('rb') as f:
         data = f.read()
@@ -32,6 +43,22 @@ def load_public_key(path: Path):
         data = f.read()
     return serialization.load_pem_public_key(data)
 
+
+def extract_public_key_from_c(path: Path) -> bytes:
+    """Return PEM bytes embedded in a C source file."""
+    lines: list[str] = []
+    with path.open('r') as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith('"'):
+                continue
+            line = line[1:]  # drop leading quote
+            if line.endswith('";'):
+                line = line[:-2]
+            elif line.endswith('"'):
+                line = line[:-1]
+            lines.append(line.encode().decode('unicode_escape'))
+    return ''.join(lines).encode()
 
 def sign_firmware(fw_path: Path, key) -> tuple[bytes, bytes]:
     """Return (digest, raw signature) of the firmware image."""
@@ -66,27 +93,14 @@ def main():
     p.add_argument('--pubkey', type=Path, help='Path to public key (PEM) for verification')
     args = p.parse_args()
 
-    key_path = args.key or os.environ.get('OTA_PRIVATE_KEY')
-    if key_path:
-        key_path = Path(key_path)
-        if not key_path.exists():
-            print(f'Private key {key_path} not found', file=sys.stderr)
-            return 1
-    else:
-        key_path = Path('private_key.pem')
-        if not key_path.exists():
-            key = ec.generate_private_key(ec.SECP256R1())
-            with key_path.open('wb') as f:
-                f.write(
-                    key.private_bytes(
-                        encoding=serialization.Encoding.PEM,
-                        format=serialization.PrivateFormat.TraditionalOpenSSL,
-                        encryption_algorithm=serialization.NoEncryption(),
-                    )
-                )
-            print(f'Generated new private key at {key_path}', file=sys.stderr)
+    key_path = args.key or os.environ.get('OTA_PRIVATE_KEY') or 'private_key.pem'
+    key_path = Path(key_path)
+    if not key_path.exists():
+        print(f'Private key {key_path} not found', file=sys.stderr)
+        return 1
 
     pubkey_path = args.pubkey or os.environ.get('OTA_PUBLIC_KEY')
+    pubkey = None
     if pubkey_path:
         pubkey_path = Path(pubkey_path)
         if not pubkey_path.exists():
@@ -94,7 +108,27 @@ def main():
             return 1
         pubkey = load_public_key(pubkey_path)
     else:
-        pubkey = None
+        candidate = Path('ota_pubkey.pem')
+        if candidate.exists():
+            pubkey = load_public_key(candidate)
+        else:
+            ota_c = Path('main/ota_pubkey.c')
+            if ota_c.exists():
+                try:
+                    pem_data = extract_public_key_from_c(ota_c)
+                    pubkey = serialization.load_pem_public_key(pem_data)
+                except Exception as e:
+                    print(f'Failed to parse {ota_c}: {e}', file=sys.stderr)
+                    return 1
+            else:
+                try:
+                    pubkey = serialization.load_pem_public_key(DEFAULT_PUBLIC_KEY_PEM)
+                except Exception as e:
+                    print(f'Failed to load built-in public key: {e}', file=sys.stderr)
+                    return 1
+    if pubkey is None:
+        print('Public key not found; provide --pubkey or ota_pubkey.pem', file=sys.stderr)
+        return 1
 
     fw_path = Path('build/main.bin')
     if not fw_path.exists():
@@ -108,35 +142,34 @@ def main():
     with sig_path.open('wb') as f:
         f.write(signature)
 
-    if pubkey:
-        derived = key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        expected = pubkey.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        if derived != expected:
-            print('Private key does not match provided public key', file=sys.stderr)
-            return 1
-        try:
-            if isinstance(pubkey, rsa.RSAPublicKey):
-                pubkey.verify(
-                    signature,
-                    digest,
-                    padding.PKCS1v15(),
-                    utils.Prehashed(hashes.SHA256()),
-                )
-            else:
-                pubkey.verify(
-                    signature,
-                    digest,
-                    ec.ECDSA(utils.Prehashed(hashes.SHA256())),
-                )
-        except InvalidSignature:
-            print('Signature verification failed', file=sys.stderr)
-            return 1
+    derived = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    expected = pubkey.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    if derived != expected:
+        print('Private key does not match provided public key', file=sys.stderr)
+        return 1
+    try:
+        if isinstance(pubkey, rsa.RSAPublicKey):
+            pubkey.verify(
+                signature,
+                digest,
+                padding.PKCS1v15(),
+                utils.Prehashed(hashes.SHA256()),
+            )
+        else:
+            pubkey.verify(
+                signature,
+                digest,
+                ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+            )
+    except InvalidSignature:
+        print('Signature verification failed', file=sys.stderr)
+        return 1
 
     print(json.dumps({'signature_path': str(sig_path)}))
     return 0


### PR DESCRIPTION
## Summary
- require existing private key and fail if missing
- load OTA public key from argument, environment, PEM file, embedded C source, or built-in default
- verify firmware signature matches provided public key

## Testing
- `python -m py_compile sign_and_upload_release.py`
- `ruff check sign_and_upload_release.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1aaba665c832195d99ae73306eed6