### PR TITLE
Clarify private key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Use `sign_and_upload_release.py` to sign the firmware binary located at
 `build/main.bin`. The script writes the signature to `build/main.bin.sig` using
 an ECDSA or RSA private key that matches the public key embedded in the device.
+Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable. If
+neither is supplied, `private_key.pem` in the current directory is used.
 
 ```bash
 python3 sign_and_upload_release.py --key ota_private_key.pem

--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -96,7 +96,11 @@ def main():
     key_path = args.key or os.environ.get('OTA_PRIVATE_KEY') or 'private_key.pem'
     key_path = Path(key_path)
     if not key_path.exists():
-        print(f'Private key {key_path} not found', file=sys.stderr)
+        print(
+            f"Private key {key_path} not found. Provide a key with --key or set "
+            "the OTA_PRIVATE_KEY environment variable.",
+            file=sys.stderr,
+        )
         return 1
 
     pubkey_path = args.pubkey or os.environ.get('OTA_PUBLIC_KEY')


### PR DESCRIPTION
## Summary
- Explain how to provide the firmware signing key when it is missing
- Document key discovery behavior in README

## Testing
- `python sign_and_upload_release.py`
- `python -m py_compile sign_and_upload_release.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae7c4ab48321b0dd4e1b9aecd47f