### PR TITLE
docs: add key generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ python3 sign_and_upload_release.py --key ota_private_key.pem
 
 The generated signature is roughly 64–72 bytes for ECDSA or 256 bytes for RSA
 keys.
+
+### Generating a private key
+
+If you do not yet have a signing key, create one before running the script.
+`espsecure.py` from ESP-IDF can generate an ECDSA key suitable for signing:
+
+```bash
+espsecure.py generate_signing_key --version 2 private_key.pem
+```
+
+Alternatively, OpenSSL can create ECDSA or RSA keys:
+
+```bash
+# ECDSA P-256
+openssl ecparam -genkey -name prime256v1 -noout -out private_key.pem
+
+# RSA 2048-bit
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out private_key.pem
+```
+
+Keep the private key secure and ensure the corresponding public key is
+embedded in your firmware.

--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -25,11 +25,12 @@ from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa, utils
 from cryptography.hazmat.primitives import serialization
 
 
-DEFAULT_PUBLIC_KEY_PEM = b"""-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdvNFFIe+YXpUxiwFYlWAy3M3t6Sa
-BP6750XmINFU950HVj8YfJIa/ILfYQKMxiCrhiyzcz09kkRKY8iW8zrfhQ==
------END PUBLIC KEY-----
-"""
+DEFAULT_PUBLIC_KEY_PEM = (
+    b"-----BEGIN PUBLIC KEY-----\n"
+    b"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdvNFFIe+YXpUxiwFYlWAy3M3t6Sa\n"
+    b"BP6750XmINFU950HVj8YfJIa/ILfYQKMxiCrhiyzcz09kkRKY8iW8zrfhQ==\n"
+    b"-----END PUBLIC KEY-----\n"
+)
 
 
 def load_private_key(path: Path):


### PR DESCRIPTION
## Summary
- document how to generate a signing key using espsecure.py or OpenSSL
- embed default OTA public key for fallback verification

## Testing
- `python -m py_compile sign_and_upload_release.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1af59dc7c8321aaa642f1c9b03340