### PR TITLE
Allow OTA_PUBLIC_KEY to contain inline PEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 Use `sign_and_upload_release.py` to sign the firmware binary located at
 `build/main.bin`. The script writes the signature to `build/main.bin.sig` using
 an ECDSA or RSA private key that matches the public key embedded in the device.
-Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable. If
-neither is supplied, `private_key.pem` in the current directory is used.
+Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable.
+`OTA_PRIVATE_KEY` accepts either a path to the PEM file or the PEM data itself.
+The corresponding public key is loaded from `--pubkey`, `OTA_PUBLIC_KEY`,
+`ota_pubkey.pem` or `main/ota_pubkey.c`. `OTA_PUBLIC_KEY` also accepts either a
+path or the PEM contents. If neither `--key` nor `OTA_PRIVATE_KEY` is supplied,
+`private_key.pem` in the current directory is used.
 
 ```bash
 python3 sign_and_upload_release.py --key ota_private_key.pem


### PR DESCRIPTION
## Summary
- parse `OTA_PUBLIC_KEY` as either a path or inline PEM data
- document the new `OTA_PUBLIC_KEY` handling in the signing instructions

## Testing
- `python -m py_compile sign_and_upload_release.py`
- `OTA_PRIVATE_KEY="$(cat private_key.pem)" OTA_PUBLIC_KEY="$(cat public_key.pem)" python sign_and_upload_release.py`
- `OTA_PRIVATE_KEY=private_key.pem OTA_PUBLIC_KEY=public_key.pem python sign_and_upload_release.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1b206ecd88321bbd6bcac0ce2844f