### PR TITLE
Ensure signing key matches firmware public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ an ECDSA or RSA private key that matches the public key embedded in the device.
 Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable.
 `OTA_PRIVATE_KEY` accepts either a path to the PEM file or the PEM data itself.
 If neither is supplied, `private_key.pem` in the current directory is used.
+If no public key is specified, the script checks the key embedded in
+`main/ota_pubkey.c` (or a built-in default) and refuses to sign if the private
+key does not match.
 
 ```bash
 python3 sign_and_upload_release.py --key ota_private_key.pem
@@ -37,3 +40,9 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out private_key.pe
 
 Keep the private key secure and ensure the corresponding public key is
 embedded in your firmware.
+
+## OTA verification
+
+The device embeds the trusted public key in `main/ota_pubkey.c`. During an OTA
+update it downloads `main.bin` and its signature, hashes the image, and verifies
+the signature against the embedded key before activating the update.

--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -160,12 +160,6 @@ def main():
         print('Firmware binary build/main.bin not found', file=sys.stderr)
         return 1
 
-    digest, signature = sign_firmware(fw_path, key)
-
-    sig_path = fw_path.with_suffix(fw_path.suffix + '.sig')
-    with sig_path.open('wb') as f:
-        f.write(signature)
-
     derived = key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
@@ -177,6 +171,8 @@ def main():
     if derived != expected:
         print('Private key does not match provided public key', file=sys.stderr)
         return 1
+
+    digest, signature = sign_firmware(fw_path, key)
     try:
         if isinstance(pubkey, rsa.RSAPublicKey):
             pubkey.verify(
@@ -194,6 +190,10 @@ def main():
     except InvalidSignature:
         print('Signature verification failed', file=sys.stderr)
         return 1
+
+    sig_path = fw_path.with_suffix(fw_path.suffix + '.sig')
+    with sig_path.open('wb') as f:
+        f.write(signature)
 
     print(json.dumps({'signature_path': str(sig_path)}))
     return 0


### PR DESCRIPTION
## Summary
- check that the signing private key matches the firmware's public key before generating a signature
- document that the script falls back to the embedded key and describe OTA signature verification

## Testing
- `python -m py_compile sign_and_upload_release.py`

------
https://chatgpt.com/codex/tasks/task_e_68c44a71271c8321b60816b66dcc76ee