### PR TITLE
Allow base64 encoded private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Use `sign_and_upload_release.py` to sign the firmware binary located at
 `build/main.bin`. The script writes the signature to `build/main.bin.sig` using
 an ECDSA or RSA private key that matches the public key embedded in the device.
 Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable.
-`OTA_PRIVATE_KEY` accepts either a path to the PEM file or the PEM data itself.
+`OTA_PRIVATE_KEY` accepts either a path to the PEM file, the PEM data itself,
+or a base64-encoded key.
 If neither is supplied, `private_key.pem` in the current directory is used.
 If no public key is specified, the script checks the key embedded in
 `main/ota_pubkey.c` (or a built-in default) and refuses to sign if the private

--- a/sign_and_upload_release.py
+++ b/sign_and_upload_release.py
@@ -14,6 +14,7 @@ success a JSON object describing the signature file is written to stdout, which
 can be consumed by GitHub Actions or the GitHub API.
 """
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -111,8 +112,12 @@ def main():
                 try:
                     key = serialization.load_pem_private_key(key_env.encode(), password=None)
                 except Exception:
-                    print('Failed to parse private key from OTA_PRIVATE_KEY', file=sys.stderr)
-                    return 1
+                    try:
+                        der = base64.b64decode(key_env)
+                        key = serialization.load_der_private_key(der, password=None)
+                    except Exception:
+                        print('Failed to parse private key from OTA_PRIVATE_KEY', file=sys.stderr)
+                        return 1
         else:
             default_path = Path('private_key.pem')
             if not default_path.exists():


### PR DESCRIPTION
## Summary
- support base64-encoded private key in OTA_PRIVATE_KEY
- document base64 private key support

## Testing
- `python -m py_compile sign_and_upload_release.py`
- `python sign_and_upload_release.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c44c6127f883218c83502177d98926