### PR TITLE
Allow base64 encoded private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Use `sign_and_upload_release.py` to sign the firmware binary located at
 `build/main.bin`. The script writes the signature to `build/main.bin.sig` using
 an ECDSA or RSA private key that matches the public key embedded in the device.
 Specify the key with `--key` or the `OTA_PRIVATE_KEY` environment variable.
-`OTA_PRIVATE_KEY` accepts either a path to the PEM file or the PEM data itself.
-If neither is supplied, `private_key.pem` in the current directory is used.
-If no public key is specified, the script checks the key embedded in
-`main/ota_pubkey.c` (or a built-in default) and refuses to sign if the private
-key does not match.
+`OTA_PRIVATE_KEY` accepts either a path to the PEM file, the PEM data itself,
+or a base64-encoded key.
+The corresponding public key is loaded from `--pubkey`, `OTA_PUBLIC_KEY`,
+`ota_pubkey.pem` or `main/ota_pubkey.c`. `OTA_PUBLIC_KEY` also accepts either a
+path or the PEM contents.
+If neither `--key` nor `OTA_PRIVATE_KEY` is supplied, `private_key.pem` in the
+current directory is used. If no public key is specified, the script checks the
+key embedded in `main/ota_pubkey.c` (or a built-in default) and refuses to sign
+if the private key does not match.
 
 ```bash
 python3 sign_and_upload_release.py --key ota_private_key.pem


### PR DESCRIPTION
## Summary
- support base64-encoded private key in OTA_PRIVATE_KEY
- allow loading OTA_PUBLIC_KEY from a path or PEM data
- document base64 private key and public key environment variable support

## Testing
- `python -m py_compile sign_and_upload_release.py`
- `python sign_and_upload_release.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c44c6127f883218c83502177d98926