### PR TITLE
Avoid reboot on WiFi disconnect

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -12,4 +12,10 @@ menu "StudioPieters"
               help
                   The GPIO number the button is connected to.
 
+      config WIFI_CONFIG_RESTART_ON_DISCONNECT
+              bool "Restart when WiFi is disconnected"
+              default n
+              help
+                  Enable this option to reboot the device if the WiFi connection is lost.
+
 endmenu

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -1067,13 +1067,19 @@ void wifi_config_legacy_support_on_event(wifi_config_event_t event) {
                                     WIFI_READY_TASK_PRIORITY,
                                     NULL);
                 }
-        }
-#ifndef WIFI_CONFIG_NO_RESTART
-        else if (event == WIFI_CONFIG_DISCONNECTED) {
+        } else if (event == WIFI_CONFIG_DISCONNECTED) {
                 INFO("WiFi disconnected event received");
+#ifdef CONFIG_WIFI_CONFIG_RESTART_ON_DISCONNECT
+                INFO("Restarting due to WiFi disconnect");
                 esp_restart();
-        }
+#else
+                INFO("Attempting to reconnect to WiFi");
+                esp_err_t err = esp_wifi_connect();
+                if (err != ESP_OK) {
+                        ERROR("Reconnection failed: %s", esp_err_to_name(err));
+                }
 #endif
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- Attempt reconnection on WiFi disconnect instead of rebooting
- Add Kconfig option to enable reboot-on-disconnect behavior

## Testing
- `idf.py build`

------
https://chatgpt.com/codex/tasks/task_e_68c45cdd43fc83218b1e53be171a2338