### PR TITLE
Ensure WiFi config tasks stop before switching modes

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -735,6 +735,7 @@ static void http_task(void *arg) {
         }
 
         lwip_close(listenfd);
+        context->http_task_handle = NULL;
         vTaskDelete(NULL);
 }
 
@@ -749,6 +750,8 @@ static void http_stop() {
                 return;
 
         xTaskNotify(context->http_task_handle, 1, eSetValueWithOverwrite);
+        while (context->http_task_handle)
+                vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 
@@ -833,6 +836,7 @@ static void dns_task(void *arg)
 
         lwip_close(fd);
 
+        context->dns_task_handle = NULL;
         vTaskDelete(NULL);
 }
 
@@ -847,6 +851,8 @@ static void dns_stop() {
                 return;
 
         xTaskNotify(context->dns_task_handle, 1, eSetValueWithOverwrite);
+        while (context->dns_task_handle)
+                vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 


### PR DESCRIPTION
## Summary
- avoid crashes by waiting for HTTP and DNS tasks to exit before changing WiFi mode

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68c535d6d7c08321aff1ddfc05a743a8