### PR TITLE
Enable WiFi readiness logging

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -7,7 +7,8 @@ CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 
 
 # Binary Size Reduction
-CONFIG_LOG_DEFAULT_LEVEL_ERROR=y
+# Enable info-level logging so runtime messages like WiFi readiness are visible
+CONFIG_LOG_DEFAULT_LEVEL_INFO=y
 CONFIG_ESP_CONSOLE_UART_DEFAULT=n
 
 # TLS cert bundle


### PR DESCRIPTION
## Summary
- switch default log level to INFO to show runtime messages like WiFi readiness

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68c59f9f9ed48321b6279e827f3d5262