### PR TITLE
Light LED after saving configuration

### DIFF
--- a/main/include/github_update.h
+++ b/main/include/github_update.h
@@ -6,6 +6,7 @@ esp_err_t save_fw_config(const char *repo, bool pre);
 bool load_fw_config(char *repo, size_t repo_len, bool *pre);
 esp_err_t save_led_config(bool enabled, int gpio);
 bool load_led_config(bool *enabled, int *gpio);
+void led_config_update(bool enabled, int gpio);
 
 esp_err_t github_update_if_needed(const char *repo, bool prerelease);
 esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url);

--- a/main/main.c
+++ b/main/main.c
@@ -153,6 +153,14 @@ void factory_reset() {
     }
 }
 
+void led_config_update(bool enabled, int gpio) {
+    led_write(false);
+    led_enabled = enabled;
+    led_gpio = gpio;
+    led_on = enabled;
+    gpio_init();
+}
+
 // Task button
 void button_task(void *pvParameter) {
     ESP_LOGI(TAG, "Button task started");

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -508,6 +508,7 @@ static void wifi_config_server_on_settings_update(client_t *client) {
         gpio = atoi(gpio_param->value);
     }
     save_led_config(led, gpio);
+    led_config_update(led, gpio);
 
     form_params_free(form);
 


### PR DESCRIPTION
## Summary
- expose `led_config_update` to apply LED settings at runtime
- trigger LED configuration after saving settings so indicator lights immediately

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c77f6abc83218a46845ced66a830