### PR TITLE
Add update wrapper for LED example

### DIFF
--- a/example/led/main/CMakeLists.txt
+++ b/example/led/main/CMakeLists.txt
@@ -1,4 +1,25 @@
 idf_component_register(
-    SRCS "main.c" "esp32-lcm.c"
-    REQUIRES freertos esp_wifi nvs_flash driver esp32-homekit
+    SRCS
+        "main.c"
+        "esp32-lcm.c"
+        "../../../main/github_update.c"
+    INCLUDE_DIRS
+        "."
+    PRIV_INCLUDE_DIRS
+        "../../../main/include"
+    REQUIRES
+        app_update
+        driver
+        esp32-homekit
+        esp_event
+        esp_http_client
+        esp_https_ota
+        esp_netif
+        esp_timer
+        esp_wifi
+        freertos
+        http_parser
+        json
+        mbedtls
+        nvs_flash
 )

--- a/example/led/main/esp32-lcm.c
+++ b/example/led/main/esp32-lcm.c
@@ -21,15 +21,19 @@
    for more information visit https://www.studiopieters.nl
  **/
  
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 
+#include <esp_err.h>
 #include <esp_wifi.h>
 #include <esp_event.h>
 #include <esp_log.h>
 #include <esp_netif.h>
 #include <nvs.h>
 #include <nvs_flash.h>
+
+#include "github_update.h"
 
 static const char *TAG = "WIFI";
 
@@ -182,4 +186,17 @@ esp_err_t wifi_stop(void) {
     if (r2 != ESP_OK) return r2;
     if (r3 != ESP_OK) return r3;
     return ESP_OK;
+}
+
+esp_err_t lcm_update(void) {
+    char repo[96] = {0};
+    bool prerelease = false;
+
+    if (!load_fw_config(repo, sizeof(repo), &prerelease)) {
+        ESP_LOGW(TAG, "Geen firmware-config gevonden in NVS; update wordt overgeslagen");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    ESP_LOGI(TAG, "Controleer firmware-update voor repo=%s (prerelease=%d)", repo, prerelease);
+    return github_update_if_needed(repo, prerelease);
 }

--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -12,6 +12,9 @@ esp_err_t wifi_start(void (*on_ready)(void));
 // Optioneel: stop WiFi netjes
 esp_err_t wifi_stop(void);
 
+// Controleer op firmware-updates via GitHub (config via NVS)
+esp_err_t lcm_update(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- expose a new `lcm_update` helper in the LED example header and implement it via `github_update_if_needed`
- add the shared github update module to the LED component build configuration

## Testing
- idf.py reconfigure

------
https://chatgpt.com/codex/tasks/task_e_68c83cd9f02483219d293bc58b653d26