### PR TITLE
Add GPIO15 triggered lifecycle update task

### DIFF
--- a/example/led/main/CMakeLists.txt
+++ b/example/led/main/CMakeLists.txt
@@ -1,4 +1,22 @@
 idf_component_register(
-    SRCS "main.c" "esp32-lcm.c"
-    REQUIRES freertos esp_wifi nvs_flash driver esp32-homekit
+    SRCS
+        "main.c"
+        "esp32-lcm.c"
+        "../../../main/github_update.c"
+    INCLUDE_DIRS
+        "."
+        "../../../main/include"
+    REQUIRES
+        freertos
+        esp_wifi
+        esp_event
+        esp_netif
+        nvs_flash
+        driver
+        esp_http_client
+        esp_https_ota
+        app_update
+        mbedtls
+        json
+        esp32-homekit
 )

--- a/example/led/main/esp32-lcm.c
+++ b/example/led/main/esp32-lcm.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include <esp_err.h>
 #include <esp_wifi.h>
 #include <esp_event.h>
 #include <esp_log.h>
@@ -182,4 +183,9 @@ esp_err_t wifi_stop(void) {
     if (r2 != ESP_OK) return r2;
     if (r3 != ESP_OK) return r3;
     return ESP_OK;
+}
+
+esp_err_t lcm_update(void) {
+    ESP_LOGW(TAG, "lcm_update is not implemented in this example");
+    return ESP_ERR_NOT_SUPPORTED;
 }

--- a/example/led/main/esp32-lcm.c
+++ b/example/led/main/esp32-lcm.c
@@ -32,6 +32,8 @@
 #include <nvs.h>
 #include <nvs_flash.h>
 
+#include "github_update.h"
+
 static const char *TAG = "WIFI";
 
 #define CHECK_ERROR(x) do {                      \
@@ -186,6 +188,16 @@ esp_err_t wifi_stop(void) {
 }
 
 esp_err_t lcm_update(void) {
-    ESP_LOGW(TAG, "lcm_update is not implemented in this example");
-    return ESP_ERR_NOT_SUPPORTED;
+    char repo[96] = {0};
+    bool prerelease = false;
+
+    if (!load_fw_config(repo, sizeof(repo), &prerelease)) {
+        ESP_LOGW(TAG,
+                 "Geen firmware-config gevonden in NVS; update wordt overgeslagen");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    ESP_LOGI(TAG, "Controleer firmware-update voor repo=%s (prerelease=%d)", repo,
+             prerelease);
+    return github_update_if_needed(repo, prerelease);
 }

--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -12,6 +12,9 @@ esp_err_t wifi_start(void (*on_ready)(void));
 // Optioneel: stop WiFi netjes
 esp_err_t wifi_stop(void);
 
+// Trigger een firmware update via de lifecycle manager.
+esp_err_t lcm_update(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -27,6 +27,7 @@
 #include <nvs_flash.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <freertos/queue.h>
 #include <driver/gpio.h>
 #include <homekit/homekit.h>
 #include <homekit/characteristics.h>
@@ -51,18 +52,22 @@ void handle_error(esp_err_t err) {
 // LED control
 #define LED_GPIO CONFIG_ESP_LED_GPIO
 #define UPDATE_BUTTON_GPIO GPIO_NUM_15
-#define UPDATE_POLL_INTERVAL_MS 50
 #define UPDATE_DEBOUNCE_MS 50
 #define LED_BLINK_INTERVAL_MS 200
 bool led_on = false;
 
 static TaskHandle_t led_blink_task_handle = NULL;
 static bool led_blinking = false;
+static QueueHandle_t s_update_evt_queue = NULL;
+static volatile TickType_t s_last_button_isr_tick = 0;
+
+#define UPDATE_DEBOUNCE_TICKS pdMS_TO_TICKS(UPDATE_DEBOUNCE_MS)
 
 static void led_blink_task(void *arg);
 void led_blinking_start(void);
 void led_blinking_stop(void);
 static void lcm_update_task(void *arg);
+static void update_button_isr(void *arg);
 
 void led_write(bool on) {
         gpio_set_level(LED_GPIO, on ? 1 : 0);
@@ -111,6 +116,25 @@ void led_blinking_stop(void) {
         }
 }
 
+static void IRAM_ATTR update_button_isr(void *arg) {
+        if (!s_update_evt_queue) {
+                return;
+        }
+
+        TickType_t now = xTaskGetTickCountFromISR();
+        if ((now - s_last_button_isr_tick) < UPDATE_DEBOUNCE_TICKS) {
+                return;
+        }
+        s_last_button_isr_tick = now;
+
+        uint32_t evt = 1;
+        BaseType_t higher_prio_task_woken = pdFALSE;
+        xQueueSendFromISR(s_update_evt_queue, &evt, &higher_prio_task_woken);
+        if (higher_prio_task_woken == pdTRUE) {
+                portYIELD_FROM_ISR();
+        }
+}
+
 // All GPIO Settings
 void gpio_init() {
         gpio_reset_pin(LED_GPIO); // Reset GPIO pin to avoid conflicts
@@ -125,38 +149,38 @@ void gpio_init() {
                 .mode = GPIO_MODE_INPUT,
                 .pull_up_en = GPIO_PULLUP_ENABLE,
                 .pull_down_en = GPIO_PULLDOWN_DISABLE,
-                .intr_type = GPIO_INTR_DISABLE,
+                .intr_type = GPIO_INTR_NEGEDGE,
         };
         CHECK_ERROR(gpio_config(&button_conf));
+
+        esp_err_t isr_err = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
+        if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
+                CHECK_ERROR(isr_err);
+        }
+
+        CHECK_ERROR(gpio_isr_handler_add(UPDATE_BUTTON_GPIO, update_button_isr, NULL));
 }
 
 static void lcm_update_task(void *arg) {
-        bool last_pressed = false;
+        uint32_t evt = 0;
 
-        while (1) {
-                bool pressed = gpio_get_level(UPDATE_BUTTON_GPIO) == 0;
+        while (xQueueReceive(s_update_evt_queue, &evt, portMAX_DELAY) == pdTRUE) {
+                (void)evt;
+                ESP_LOGI("LCM", "Update button pressed – checking for updates");
 
-                if (pressed && !last_pressed) {
-                        vTaskDelay(pdMS_TO_TICKS(UPDATE_DEBOUNCE_MS));
-                        if (gpio_get_level(UPDATE_BUTTON_GPIO) == 0) {
-                                ESP_LOGI("LCM", "Update button pressed – checking for updates");
-                                esp_err_t update_res = lcm_update();
-                                if (update_res == ESP_OK) {
-                                        ESP_LOGI("LCM", "Update successful, restarting device");
-                                        vTaskDelay(pdMS_TO_TICKS(100));
-                                        esp_restart();
-                                } else {
-                                        ESP_LOGE("LCM", "Update failed: %s", esp_err_to_name(update_res));
-                                }
+                led_blinking_start();
+                esp_err_t update_res = lcm_update();
+                led_blinking_stop();
 
-                                while (gpio_get_level(UPDATE_BUTTON_GPIO) == 0) {
-                                        vTaskDelay(pdMS_TO_TICKS(UPDATE_POLL_INTERVAL_MS));
-                                }
-                        }
+                if (update_res == ESP_OK) {
+                        ESP_LOGI("LCM", "Update succesvol, apparaat wordt herstart");
+                        vTaskDelay(pdMS_TO_TICKS(100));
+                        esp_restart();
+                } else if (update_res == ESP_ERR_NOT_FOUND) {
+                        ESP_LOGW("LCM", "Geen firmware-config gevonden; update overgeslagen");
+                } else {
+                        ESP_LOGE("LCM", "Update mislukt: %s", esp_err_to_name(update_res));
                 }
-
-                last_pressed = pressed;
-                vTaskDelay(pdMS_TO_TICKS(UPDATE_POLL_INTERVAL_MS));
         }
 }
 
@@ -254,6 +278,12 @@ void app_main(void) {
                 ret = nvs_flash_init();
         }
         CHECK_ERROR(ret);
+
+        s_update_evt_queue = xQueueCreate(4, sizeof(uint32_t));
+        if (!s_update_evt_queue) {
+                ESP_LOGE("LCM", "Kon update-queue niet aanmaken");
+                handle_error(ESP_ERR_NO_MEM);
+        }
 
         // Start GPIO / LED
         gpio_init();


### PR DESCRIPTION
## Summary
- configure GPIO 15 as an input with pull-up and start a task that debounces presses
- call lcm_update() when the button is pressed and restart on success
- expose a default lcm_update() implementation and header declaration for the example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c83cdad09c8321959d76a68f46b8d0