### PR TITLE
Add GPIO 15 update button to LED example

### DIFF
--- a/example/led/README.md
+++ b/example/led/README.md
@@ -17,6 +17,7 @@ Connect `LED` pin to the following pin:
 | Name | Description | Defaults |
 |------|-------------|----------|
 | `CONFIG_ESP_LED_GPIO` | GPIO number for `LED` pin | "2" Default |
+| `CONFIG_ESP_UPDATE_BUTTON_GPIO` | GPIO number for the firmware update button (active low) | "15" Default |
 
 ## Scheme
 
@@ -32,5 +33,6 @@ Connect `LED` pin to the following pin:
 ## Notes
 
 - Choose your GPIO number under `StudioPieters` in `menuconfig`. The default is `2` (On an ESP32 WROOM 32D).
+- Configure the update button GPIO under `StudioPieters` in `menuconfig` if you use a different pin. A momentary push button tied to ground on GPIO `15` (default) will trigger the firmware update check.
 - Set your `WiFi SSID` and `WiFi Password` under `StudioPieters` in `menuconfig`.
 - **Optional:** You can change `HomeKit Setup Code` and `HomeKit Setup ID` under `StudioPieters` in `menuconfig`. _(Note: you need to make a new QR-CODE to make it work.)_

--- a/example/led/main/Kconfig.projbuild
+++ b/example/led/main/Kconfig.projbuild
@@ -6,6 +6,12 @@ menu "StudioPieters"
               help
                   The GPIO number the LED is connected to.
 
+      config ESP_UPDATE_BUTTON_GPIO
+              int "Set the GPIO for the update button"
+              default 15
+              help
+                  The GPIO number the firmware update button is connected to.
+
       config ESP_SETUP_CODE
               string "HomeKit Setup Code"
               default "338-77-883"

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -26,6 +26,7 @@
 #include <nvs_flash.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <freertos/queue.h>
 #include <driver/gpio.h>
 #include <homekit/homekit.h>
 #include <homekit/characteristics.h>
@@ -49,7 +50,13 @@ void handle_error(esp_err_t err) {
 
 // LED control
 #define LED_GPIO CONFIG_ESP_LED_GPIO
+#define UPDATE_BUTTON_GPIO CONFIG_ESP_UPDATE_BUTTON_GPIO
 bool led_on = false;
+
+static QueueHandle_t s_update_button_queue = NULL;
+
+static void IRAM_ATTR update_button_isr(void *arg);
+static void update_button_task(void *arg);
 
 void led_write(bool on) {
         gpio_set_level(LED_GPIO, on ? 1 : 0);
@@ -60,6 +67,65 @@ void gpio_init() {
         gpio_reset_pin(LED_GPIO); // Reset GPIO pin to avoid conflicts
         gpio_set_direction(LED_GPIO, GPIO_MODE_OUTPUT);
         led_write(led_on);
+
+        gpio_reset_pin(UPDATE_BUTTON_GPIO);
+        gpio_config_t button_conf = {
+                .pin_bit_mask = 1ULL << UPDATE_BUTTON_GPIO,
+                .mode = GPIO_MODE_INPUT,
+                .pull_up_en = GPIO_PULLUP_ENABLE,
+                .pull_down_en = GPIO_PULLDOWN_DISABLE,
+                .intr_type = GPIO_INTR_NEGEDGE,
+        };
+        CHECK_ERROR(gpio_config(&button_conf));
+
+        if (!s_update_button_queue) {
+                s_update_button_queue = xQueueCreate(4, sizeof(uint32_t));
+                if (!s_update_button_queue) {
+                        ESP_LOGE("ERROR", "Failed to allocate update button queue");
+                        handle_error(ESP_ERR_NO_MEM);
+                }
+        }
+
+        esp_err_t isr_err = gpio_install_isr_service(0);
+        if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
+                handle_error(isr_err);
+        }
+        CHECK_ERROR(gpio_isr_handler_add(UPDATE_BUTTON_GPIO, update_button_isr, (void *)UPDATE_BUTTON_GPIO));
+}
+
+static void IRAM_ATTR update_button_isr(void *arg) {
+        if (!s_update_button_queue) {
+                return;
+        }
+        uint32_t gpio_num = (uint32_t)arg;
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        xQueueSendFromISR(s_update_button_queue, &gpio_num, &xHigherPriorityTaskWoken);
+        if (xHigherPriorityTaskWoken == pdTRUE) {
+                portYIELD_FROM_ISR();
+        }
+}
+
+static void update_button_task(void *arg) {
+        uint32_t io_num;
+        while (xQueueReceive(s_update_button_queue, &io_num, portMAX_DELAY)) {
+                vTaskDelay(pdMS_TO_TICKS(50));
+                if (gpio_get_level(io_num) == 0) {
+                        ESP_LOGI("INFORMATION", "Update button pressed, checking for firmware updates...");
+                        esp_err_t err = lcm_update();
+                        if (err == ESP_OK) {
+                                ESP_LOGI("INFORMATION", "Firmware update check completed (device restarts if an update was applied).");
+                        } else if (err == ESP_ERR_NOT_FOUND) {
+                                ESP_LOGW("WARNING", "Firmware update configuration missing; skipping update.");
+                        } else {
+                                ESP_LOGE("ERROR", "Firmware update failed: %s", esp_err_to_name(err));
+                        }
+
+                        while (gpio_get_level(io_num) == 0) {
+                                vTaskDelay(pdMS_TO_TICKS(10));
+                        }
+                }
+        }
+        vTaskDelete(NULL);
 }
 
 // Accessory identification
@@ -155,6 +221,11 @@ void app_main(void) {
 
         // Start GPIO / LED
         gpio_init();
+
+        if (xTaskCreate(update_button_task, "update_button_task", 4096, NULL, 5, NULL) != pdPASS) {
+                ESP_LOGE("ERROR", "Failed to create update button task");
+                handle_error(ESP_FAIL);
+        }
 
         // Start WiFi op basis van NVS en geef callback door
         CHECK_ERROR(wifi_start(on_wifi_ready));

--- a/example/led/sdkconfig.defaults
+++ b/example/led/sdkconfig.defaults
@@ -1,6 +1,7 @@
 #
 # StudioPieters
 #
+CONFIG_ESP_UPDATE_BUTTON_GPIO=15
 
 # General Optimization
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y


### PR DESCRIPTION
## Summary
- add lifecycle update button support to the LED example by configuring GPIO 15 with an ISR-driven FreeRTOS task that calls `lcm_update`
- expose a new `CONFIG_ESP_UPDATE_BUTTON_GPIO` Kconfig option with defaults for gpio and document it in the README
- update the example defaults so GPIO 15 is preselected for the update trigger

## Testing
- idf.py -C example/led build *(fails: wolfSSL HomeKit options and esp_crt_bundle_attach missing in upstream dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c84845721c8321b01b55252d594912