### PR TITLE
Fix cert bundle build error and ISR warning

### DIFF
--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -55,7 +55,7 @@ bool led_on = false;
 
 static QueueHandle_t s_update_button_queue = NULL;
 
-static void IRAM_ATTR update_button_isr(void *arg);
+static void update_button_isr(void *arg);
 static void update_button_task(void *arg);
 
 void led_write(bool on) {


### PR DESCRIPTION
## Summary
- avoid including the WolfSSL esp_crt_bundle wrapper by forward declaring esp_crt_bundle_attach based on sdkconfig flags
- guard every esp_http_client_config_t initializer that uses crt_bundle_attach so the build works whether a bundle is enabled or not
- drop the IRAM attribute from the update button ISR prototype to silence the section warning

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68c84feef9508321ae4f83952c408de3