### PR TITLE
Handle realloc failure in wifi_config_server_on_body

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -533,7 +533,19 @@ static int wifi_config_server_on_url(http_parser *parser, const char *data, size
 
 static int wifi_config_server_on_body(http_parser *parser, const char *data, size_t length) {
         client_t *client = parser->data;
-        client->body = realloc(client->body, client->body_length + length + 1);
+        if (client->disconnected)
+                return 0;
+
+        size_t new_size = client->body_length + length + 1;
+        uint8_t *new_body = realloc(client->body, new_size);
+
+        if (!new_body) {
+                ESP_LOGE("wifi_config", "Failed to allocate %zu bytes for HTTP body", new_size);
+                client->disconnected = true;
+                return 0;
+        }
+
+        client->body = new_body;
         memcpy(client->body + client->body_length, data, length);
         client->body_length += length;
         client->body[client->body_length] = 0;


### PR DESCRIPTION
## Summary
- guard the HTTP body accumulation against realloc failures
- log allocation errors, mark the client as disconnected and keep the old buffer intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca90ece8588321a31771e2491c619b