### PR TITLE
Zero fd_sets before use in http_task

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -699,6 +699,7 @@ static void http_task(void *arg) {
         fd_set fds;
         int max_fd = listenfd;
 
+        FD_ZERO(&fds);
         FD_SET(listenfd, &fds);
 
         char data[64];
@@ -714,6 +715,7 @@ static void http_task(void *arg) {
                 }
 
                 fd_set read_fds;
+                FD_ZERO(&read_fds);
                 memcpy(&read_fds, &fds, sizeof(read_fds));
 
                 struct timeval timeout = { 1, 0 }; // 1 second timeout


### PR DESCRIPTION
## Summary
- clear the http_task master fd_set before setting the listening socket
- zero the temporary read fd_set before copying tracked descriptors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caa0ddc948832193ed9aa0788fc12a