### PR TITLE
Fix serv_addr zeroing for captive portal sockets

### DIFF
--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -674,7 +674,7 @@ static void http_task(void *arg) {
 
         struct sockaddr_in serv_addr;
         int listenfd = socket(AF_INET, SOCK_STREAM, 0);
-        memset(&serv_addr, '0', sizeof(serv_addr));
+        memset(&serv_addr, 0, sizeof(serv_addr));
         serv_addr.sin_family = AF_INET;
         serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
         serv_addr.sin_port = htons(WIFI_CONFIG_SERVER_PORT);
@@ -849,7 +849,7 @@ static void dns_task(void *arg)
         struct sockaddr_in serv_addr;
         int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
-        memset(&serv_addr, '0', sizeof(serv_addr));
+        memset(&serv_addr, 0, sizeof(serv_addr));
         serv_addr.sin_family = AF_INET;
         serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
         serv_addr.sin_port = htons(53);


### PR DESCRIPTION
## Summary
- zero-fill the HTTP server sockaddr before binding with memset(&serv_addr, 0, ...)
- do the same for the DNS server socket initialization

## Testing
- `idf.py build > build.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68caa0e015e88321a6ef5558913794ea