### PR TITLE
Handle empty settings updates safely

### DIFF
--- a/main/form_urlencoded.c
+++ b/main/form_urlencoded.c
@@ -85,6 +85,11 @@ char *url_unescape(const char *buffer, size_t size) {
 
 
 form_param_t *form_params_parse(const char *s) {
+        if (!s) {
+                ESP_LOGW(TAG, "form_params_parse called with NULL input");
+                return NULL;
+        }
+
         form_param_t *params = NULL;
 
         int i = 0;

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -527,14 +527,21 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
 static void wifi_config_server_on_settings_update(client_t *client) {
-    DEBUG("Update settings, body = %s", client->body);
+        const char *body_log = client->body ? (const char *)client->body : "(null)";
+        DEBUG("Update settings, body length = %zu, body = %s", client->body_length, body_log);
 
-    form_param_t *form = form_params_parse((char *)client->body);
-    if (!form) {
-        DEBUG("Couldn't parse form data, redirecting to /settings");
-        client_send_redirect(client, 302, "/settings");
-        return;
-    }
+        if (!client->body || client->body_length == 0) {
+                DEBUG("Empty HTTP body received, redirecting to /settings");
+                client_send_redirect(client, 302, "/settings");
+                return;
+        }
+
+        form_param_t *form = form_params_parse((char *)client->body);
+        if (!form) {
+                DEBUG("Couldn't parse form data, redirecting to /settings");
+                client_send_redirect(client, 302, "/settings");
+                return;
+        }
 
     form_param_t *ssid_param = form_params_find(form, "ssid");
     form_param_t *password_param = form_params_find(form, "password");


### PR DESCRIPTION
## Summary
- guard the settings update handler against missing HTTP bodies and log the condition
- skip parsing when no payload is provided so the request is redirected safely
- harden form parameter parsing by returning NULL for NULL inputs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa6ab97b4832181069df214481b09