### PR TITLE
Optimize Wi-Fi config and OTA helpers

### DIFF
--- a/main/include/form_urlencoded.h
+++ b/main/include/form_urlencoded.h
@@ -7,6 +7,6 @@ typedef struct _form_param {
         struct _form_param *next;
 } form_param_t;
 
-form_param_t *form_params_parse(const char *s);
+form_param_t *form_params_parse(char *s);
 form_param_t *form_params_find(form_param_t *params, const char *name);
 void form_params_free(form_param_t *params);

--- a/main/include/html_utils.h
+++ b/main/include/html_utils.h
@@ -2,6 +2,14 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * Escape `input` into the caller-provided `dst` buffer. Returns true on
+ * success. When false is returned, `out_len` (if non-NULL) receives the number
+ * of bytes required, including the terminating NUL.
+ */
+bool html_escape_into(const char *input, char *dst, size_t dst_len, size_t *out_len);
 
 /**
  * Allocate and return a new string containing an HTML-escaped version of

--- a/tests/test_html_utils.c
+++ b/tests/test_html_utils.c
@@ -22,6 +22,31 @@ int main(void)
                 return 1;
         }
 
+        char into_buf[128];
+        size_t out_len = 0;
+        if (!html_escape_into(malicious, into_buf, sizeof(into_buf), &out_len)) {
+                fprintf(stderr, "html_escape_into reported failure\n");
+                free(escaped);
+                return 1;
+        }
+        if (strcmp(into_buf, expected) != 0 || out_len != strlen(expected)) {
+                fprintf(stderr, "html_escape_into produced unexpected result: %s (len=%zu)\n", into_buf, out_len);
+                free(escaped);
+                return 1;
+        }
+        char small_buf[8];
+        size_t needed_len = 0;
+        if (html_escape_into(malicious, small_buf, sizeof(small_buf), &needed_len)) {
+                fprintf(stderr, "html_escape_into succeeded unexpectedly with small buffer\n");
+                free(escaped);
+                return 1;
+        }
+        if (needed_len != strlen(expected) + 1) {
+                fprintf(stderr, "html_escape_into reported wrong required length: %zu\n", needed_len);
+                free(escaped);
+                return 1;
+        }
+
         size_t needed = (size_t)snprintf(NULL, 0, html_network_item, "secure", escaped);
         char *buffer = malloc(needed + 1);
         if (!buffer) {


### PR DESCRIPTION
## Summary
- store Wi-Fi configuration context data in fixed buffers and harden the captive portal helpers
- add lightweight formatting helpers, safer buffer growth, and better mutex handling for network scanning
- share an HTTP JSON download helper for GitHub update checks to reduce duplication

## Testing
- gcc tests/test_html_utils.c main/html_utils.c -I main/include -I main/content -o html_utils_test
- ./html_utils_test

------
https://chatgpt.com/codex/tasks/task_e_68caaa98f5d48321b12bcc9c76e802c8