### PR TITLE
Stabilize LED blinking indicator behavior

### DIFF
--- a/main/github_update.c
+++ b/main/github_update.c
@@ -1,23 +1,23 @@
-#include <string.h>
-#include <stdlib.h>
-#include "esp_log.h"
-#include "esp_https_ota.h"
-#include "esp_http_client.h"
-#include "esp_ota_ops.h"
+#include "github_update.h"
+#include "cJSON.h"
 #include "esp_app_desc.h"
 #include "esp_crt_bundle.h"
-#include "mbedtls/sha512.h"
+#include "esp_http_client.h"
+#include "esp_https_ota.h"
 #include "esp_image_format.h"
-#include "cJSON.h"
+#include "esp_log.h"
+#include "esp_ota_ops.h"
+#include "mbedtls/sha512.h"
 #include "nvs.h"
 #include "nvs_flash.h"
-#include "github_update.h"
+#include <stdlib.h>
+#include <string.h>
 
 static const char *TAG = "github_update";
 
-// LED breathing control provided by main.c
-extern void led_breathing_start(void);
-extern void led_breathing_stop(void);
+// LED blinking control provided by main.c
+extern void led_blinking_start(void);
+extern void led_blinking_stop(void);
 
 static bool parse_version(const char *str, int *maj, int *min, int *pat) {
     *maj = *min = *pat = 0;
@@ -25,7 +25,8 @@ static bool parse_version(const char *str, int *maj, int *min, int *pat) {
         ESP_LOGE(TAG, "Version string is null");
         return false;
     }
-    if (str[0] == 'v' || str[0] == 'V') str++;
+    if (str[0] == 'v' || str[0] == 'V')
+        str++;
     int parsed = sscanf(str, "%d.%d.%d", maj, min, pat);
     if (parsed < 3) {
         ESP_LOGE(TAG, "Invalid version string: %s", str);
@@ -35,15 +36,18 @@ static bool parse_version(const char *str, int *maj, int *min, int *pat) {
     return true;
 }
 
-static int cmp_version(int aMaj, int aMin, int aPat,
-                       int bMaj, int bMin, int bPat) {
-    if (aMaj != bMaj) return aMaj - bMaj;
-    if (aMin != bMin) return aMin - bMin;
+static int cmp_version(int aMaj, int aMin, int aPat, int bMaj, int bMin,
+                       int bPat) {
+    if (aMaj != bMaj)
+        return aMaj - bMaj;
+    if (aMin != bMin)
+        return aMin - bMin;
     return aPat - bPat;
 }
 
 esp_err_t save_fw_config(const char *repo, bool pre) {
-    ESP_LOGD(TAG, "Saving firmware config repo=%s pre=%d", repo ? repo : "(null)", pre);
+    ESP_LOGD(TAG, "Saving firmware config repo=%s pre=%d",
+             repo ? repo : "(null)", pre);
     nvs_handle_t h;
     esp_err_t err = nvs_open("fwcfg", NVS_READWRITE, &h);
     if (err != ESP_OK) {
@@ -99,9 +103,11 @@ bool load_fw_config(char *repo, size_t repo_len, bool *pre) {
         nvs_close(h);
         return false;
     }
-    if (pre) *pre = pre_u8 != 0;
+    if (pre)
+        *pre = pre_u8 != 0;
     nvs_close(h);
-    ESP_LOGD(TAG, "Loaded firmware config repo=%s pre=%d", repo ? repo : "(null)", pre ? *pre : pre_u8);
+    ESP_LOGD(TAG, "Loaded firmware config repo=%s pre=%d",
+             repo ? repo : "(null)", pre ? *pre : pre_u8);
     return true;
 }
 
@@ -152,21 +158,25 @@ bool load_led_config(bool *enabled, int *gpio) {
         nvs_close(h);
         return false;
     }
-    if (enabled) *enabled = en != 0;
-    if (gpio) *gpio = (int)pin;
+    if (enabled)
+        *enabled = en != 0;
+    if (gpio)
+        *gpio = (int)pin;
     nvs_close(h);
     return true;
 }
 
-static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_len, size_t *out_len) {
+static esp_err_t download_signature(const char *url, uint8_t *buf,
+                                    size_t buf_len, size_t *out_len) {
     ESP_LOGD(TAG, "Initializing HTTP client for %s", url);
     esp_http_client_config_t cfg = {
         .url = url,
         .crt_bundle_attach = esp_crt_bundle_attach,
         .user_agent = "esp32-ota",
-        // GitHub release assets use redirects with extremely long Location headers
-        // (currently >5k and sometimes exceeding 8k), so give the HTTP client a
-        // generously sized buffer to ensure the Location header fits entirely.
+        // GitHub release assets use redirects with extremely long Location
+        // headers (currently >5k and sometimes exceeding 8k), so give the HTTP
+        // client a generously sized buffer to ensure the Location header fits
+        // entirely.
         .buffer_size = 32768,
         .buffer_size_tx = 32768,
     };
@@ -180,13 +190,15 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
     int redirects = 0;
     while (redirects < 5) {
         char cur_url[512];
-        esp_err_t url_err = esp_http_client_get_url(client, cur_url, sizeof(cur_url));
+        esp_err_t url_err =
+            esp_http_client_get_url(client, cur_url, sizeof(cur_url));
         ESP_LOGD(TAG, "Attempt %d URL: %s", redirects + 1,
                  url_err == ESP_OK ? cur_url : "(null)");
         ESP_LOGD(TAG, "Opening HTTP connection");
         err = esp_http_client_open(client, 0);
         if (err != ESP_OK) {
-            ESP_LOGE(TAG, "esp_http_client_open failed: %s", esp_err_to_name(err));
+            ESP_LOGE(TAG, "esp_http_client_open failed: %s",
+                     esp_err_to_name(err));
             esp_http_client_cleanup(client);
             return err;
         }
@@ -202,16 +214,19 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
         }
         int status = esp_http_client_get_status_code(client);
         ESP_LOGD(TAG, "HTTP status %d", status);
-        if (status == 301 || status == 302 || status == 303 || status == 307 || status == 308) {
+        if (status == 301 || status == 302 || status == 303 || status == 307 ||
+            status == 308) {
             ESP_LOGD(TAG, "Handling HTTP redirect");
             esp_err_t redir = esp_http_client_set_redirection(client);
             if (redir != ESP_OK) {
-                ESP_LOGE(TAG, "Failed to set redirection: %s", esp_err_to_name(redir));
+                ESP_LOGE(TAG, "Failed to set redirection: %s",
+                         esp_err_to_name(redir));
                 esp_http_client_close(client);
                 esp_http_client_cleanup(client);
                 return ESP_FAIL;
             }
-            if (esp_http_client_get_url(client, cur_url, sizeof(cur_url)) == ESP_OK) {
+            if (esp_http_client_get_url(client, cur_url, sizeof(cur_url)) ==
+                ESP_OK) {
                 ESP_LOGD(TAG, "Following redirect to %s", cur_url);
             }
             esp_http_client_close(client);
@@ -252,17 +267,19 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
     return ESP_FAIL;
 }
 
-static esp_err_t partition_sha384(const esp_partition_t *part, uint32_t len, uint8_t *out)
-{
+static esp_err_t partition_sha384(const esp_partition_t *part, uint32_t len,
+                                  uint8_t *out) {
     mbedtls_sha512_context ctx;
     uint8_t *buf = malloc(4096);
-    if (!buf) return ESP_ERR_NO_MEM;
+    if (!buf)
+        return ESP_ERR_NO_MEM;
     mbedtls_sha512_init(&ctx);
     mbedtls_sha512_starts(&ctx, 1); // 1 -> SHA-384
     uint32_t offset = 0;
     while (offset < len) {
         uint32_t to_read = len - offset;
-        if (to_read > 4096) to_read = 4096;
+        if (to_read > 4096)
+            to_read = 4096;
         esp_err_t r = esp_partition_read(part, offset, buf, to_read);
         if (r != ESP_OK) {
             free(buf);
@@ -284,7 +301,8 @@ esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url) {
     size_t sig_len = 0;
     esp_err_t sig_res = download_signature(sig_url, sig, sizeof(sig), &sig_len);
     if (sig_res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to download signature: %s", esp_err_to_name(sig_res));
+        ESP_LOGE(TAG, "Failed to download signature: %s",
+                 esp_err_to_name(sig_res));
         return sig_res;
     }
     ESP_LOGI(TAG, "Downloaded signature (%u bytes)", (unsigned)sig_len);
@@ -293,13 +311,15 @@ esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url) {
         return ESP_FAIL;
     }
 
-    const esp_partition_t *update_part = esp_ota_get_next_update_partition(NULL);
+    const esp_partition_t *update_part =
+        esp_ota_get_next_update_partition(NULL);
     if (!update_part) {
         ESP_LOGE(TAG, "No OTA partition available");
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "Using OTA partition at 0x%lx (%lu bytes)",
-             (unsigned long)update_part->address, (unsigned long)update_part->size);
+             (unsigned long)update_part->address,
+             (unsigned long)update_part->size);
     esp_http_client_config_t http_cfg = {
         .url = fw_url,
         .crt_bundle_attach = esp_crt_bundle_attach,
@@ -321,21 +341,24 @@ esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url) {
         return ret;
     }
     ESP_LOGI(TAG, "OTA download complete");
-    esp_partition_pos_t pos = { .offset = update_part->address, .size = update_part->size };
+    esp_partition_pos_t pos = {.offset = update_part->address,
+                               .size = update_part->size};
     esp_image_metadata_t meta;
     esp_err_t meta_res = esp_image_get_metadata(&pos, &meta);
     ESP_LOGD(TAG, "esp_image_get_metadata -> %s", esp_err_to_name(meta_res));
     if (meta_res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to get image metadata: %s", esp_err_to_name(meta_res));
+        ESP_LOGE(TAG, "Failed to get image metadata: %s",
+                 esp_err_to_name(meta_res));
         return meta_res;
     }
     uint8_t expected_hash[48];
     memcpy(expected_hash, sig, sizeof(expected_hash));
-    uint32_t expected_len = ((uint32_t)sig[48] << 24) | ((uint32_t)sig[49] << 16) |
+    uint32_t expected_len = ((uint32_t)sig[48] << 24) |
+                            ((uint32_t)sig[49] << 16) |
                             ((uint32_t)sig[50] << 8) | (uint32_t)sig[51];
     if (expected_len != meta.image_len) {
-        ESP_LOGE(TAG, "Image length mismatch: expected %u got %u", (unsigned)expected_len,
-                 (unsigned)meta.image_len);
+        ESP_LOGE(TAG, "Image length mismatch: expected %u got %u",
+                 (unsigned)expected_len, (unsigned)meta.image_len);
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "Image length verified (%u bytes)", (unsigned)meta.image_len);
@@ -355,21 +378,26 @@ esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url) {
 
 esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
     char api[256];
-    snprintf(api, sizeof(api), "https://api.github.com/repos/%s/releases%s", repo,
-             prerelease ? "?per_page=5" : "/latest");
-    esp_http_client_config_t cfg = { .url = api, .crt_bundle_attach = esp_crt_bundle_attach,
-        .user_agent = "esp32-ota" };
+    snprintf(api, sizeof(api), "https://api.github.com/repos/%s/releases%s",
+             repo, prerelease ? "?per_page=5" : "/latest");
+    esp_http_client_config_t cfg = {.url = api,
+                                    .crt_bundle_attach = esp_crt_bundle_attach,
+                                    .user_agent = "esp32-ota"};
     ESP_LOGI(TAG, "Checking updates for repo %s (pre=%d)", repo, prerelease);
     ESP_LOGD(TAG, "Release API URL: %s", api);
     const esp_app_desc_t *cur = esp_app_get_description();
     int curMaj, curMin, curPat;
-    bool curValid = parse_version(cur ? cur->version : NULL, &curMaj, &curMin, &curPat);
+    bool curValid =
+        parse_version(cur ? cur->version : NULL, &curMaj, &curMin, &curPat);
     ESP_LOGI(TAG, "Current firmware version %d.%d.%d", curMaj, curMin, curPat);
     if (!curValid) {
         ESP_LOGE(TAG, "Invalid current firmware version, assuming 0.0.0");
     }
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
-    if (!client) { ESP_LOGE(TAG, "esp_http_client_init failed"); return ESP_FAIL; }
+    if (!client) {
+        ESP_LOGE(TAG, "esp_http_client_init failed");
+        return ESP_FAIL;
+    }
     esp_err_t err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_http_client_open failed: %s", esp_err_to_name(err));
@@ -380,18 +408,25 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
     int len = esp_http_client_fetch_headers(client);
     ESP_LOGD(TAG, "Header length %d", len);
     if (len < 0) {
-        ESP_LOGE(TAG, "esp_http_client_fetch_headers failed: errno=%d", esp_http_client_get_errno(client));
+        ESP_LOGE(TAG, "esp_http_client_fetch_headers failed: errno=%d",
+                 esp_http_client_get_errno(client));
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
         return ESP_FAIL;
     }
     char *data = malloc(len + 1);
-    if (!data) { ESP_LOGE(TAG, "malloc failed"); esp_http_client_close(client); esp_http_client_cleanup(client); return ESP_ERR_NO_MEM; }
+    if (!data) {
+        ESP_LOGE(TAG, "malloc failed");
+        esp_http_client_close(client);
+        esp_http_client_cleanup(client);
+        return ESP_ERR_NO_MEM;
+    }
     int read = esp_http_client_read_response(client, data, len);
     int status = esp_http_client_get_status_code(client);
     ESP_LOGD(TAG, "Read %d bytes with HTTP status %d", read, status);
     if (read <= 0) {
-        ESP_LOGE(TAG, "esp_http_client_read_response failed: errno=%d", esp_http_client_get_errno(client));
+        ESP_LOGE(TAG, "esp_http_client_read_response failed: errno=%d",
+                 esp_http_client_get_errno(client));
         free(data);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
@@ -403,38 +438,52 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
 
     cJSON *json = cJSON_Parse(data);
     free(data);
-    if (!json) { ESP_LOGE(TAG, "cJSON_Parse failed"); return ESP_FAIL; }
+    if (!json) {
+        ESP_LOGE(TAG, "cJSON_Parse failed");
+        return ESP_FAIL;
+    }
     ESP_LOGD(TAG, "Release JSON parsed");
 
     cJSON *release = NULL;
     if (prerelease) {
         ESP_LOGD(TAG, "Prerelease mode: using first release from list");
-        if (!cJSON_IsArray(json)) { cJSON_Delete(json); return ESP_FAIL; }
+        if (!cJSON_IsArray(json)) {
+            cJSON_Delete(json);
+            return ESP_FAIL;
+        }
         release = cJSON_GetArrayItem(json, 0);
     } else {
         if (cJSON_IsArray(json)) {
             ESP_LOGD(TAG, "Array returned, searching for stable release");
-            for (int i=0; i<cJSON_GetArraySize(json); ++i) {
+            for (int i = 0; i < cJSON_GetArraySize(json); ++i) {
                 cJSON *rel = cJSON_GetArrayItem(json, i);
                 cJSON *pre = cJSON_GetObjectItem(rel, "prerelease");
-                if (!cJSON_IsTrue(pre)) { release = rel; break; }
+                if (!cJSON_IsTrue(pre)) {
+                    release = rel;
+                    break;
+                }
             }
         } else {
             ESP_LOGD(TAG, "Object returned from /latest endpoint");
             release = json;
             cJSON *pre = cJSON_GetObjectItem(release, "prerelease");
-            if (cJSON_IsTrue(pre)) release = NULL; // need to fetch list
+            if (cJSON_IsTrue(pre))
+                release = NULL; // need to fetch list
         }
         if (!release) {
             ESP_LOGW(TAG, "Falling back to full release list");
             cJSON_Delete(json);
-            snprintf(api, sizeof(api), "https://api.github.com/repos/%s/releases?per_page=5", repo);
+            snprintf(api, sizeof(api),
+                     "https://api.github.com/repos/%s/releases?per_page=5",
+                     repo);
             cfg.url = api;
             client = esp_http_client_init(&cfg);
-            if (!client) return ESP_FAIL;
+            if (!client)
+                return ESP_FAIL;
             err = esp_http_client_open(client, 0);
             if (err != ESP_OK) {
-                ESP_LOGE(TAG, "esp_http_client_open failed: %s", esp_err_to_name(err));
+                ESP_LOGE(TAG, "esp_http_client_open failed: %s",
+                         esp_err_to_name(err));
                 esp_http_client_cleanup(client);
                 return err;
             }
@@ -442,18 +491,25 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
             len = esp_http_client_fetch_headers(client);
             ESP_LOGD(TAG, "Header length %d", len);
             if (len < 0) {
-                ESP_LOGE(TAG, "esp_http_client_fetch_headers failed: errno=%d", esp_http_client_get_errno(client));
+                ESP_LOGE(TAG, "esp_http_client_fetch_headers failed: errno=%d",
+                         esp_http_client_get_errno(client));
                 esp_http_client_close(client);
                 esp_http_client_cleanup(client);
                 return ESP_FAIL;
             }
             data = malloc(len + 1);
-            if (!data) { ESP_LOGE(TAG, "malloc failed"); esp_http_client_close(client); esp_http_client_cleanup(client); return ESP_ERR_NO_MEM; }
+            if (!data) {
+                ESP_LOGE(TAG, "malloc failed");
+                esp_http_client_close(client);
+                esp_http_client_cleanup(client);
+                return ESP_ERR_NO_MEM;
+            }
             read = esp_http_client_read_response(client, data, len);
             status = esp_http_client_get_status_code(client);
             ESP_LOGD(TAG, "Read %d bytes with HTTP status %d", read, status);
             if (read <= 0) {
-                ESP_LOGE(TAG, "esp_http_client_read_response failed: errno=%d", esp_http_client_get_errno(client));
+                ESP_LOGE(TAG, "esp_http_client_read_response failed: errno=%d",
+                         esp_http_client_get_errno(client));
                 free(data);
                 esp_http_client_close(client);
                 esp_http_client_cleanup(client);
@@ -464,48 +520,72 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
             esp_http_client_cleanup(client);
             json = cJSON_Parse(data);
             free(data);
-            if (!json || !cJSON_IsArray(json) || cJSON_GetArraySize(json)==0) { ESP_LOGE(TAG, "No releases in list"); cJSON_Delete(json); return ESP_FAIL; }
-            for (int i=0; i<cJSON_GetArraySize(json); ++i) {
+            if (!json || !cJSON_IsArray(json) ||
+                cJSON_GetArraySize(json) == 0) {
+                ESP_LOGE(TAG, "No releases in list");
+                cJSON_Delete(json);
+                return ESP_FAIL;
+            }
+            for (int i = 0; i < cJSON_GetArraySize(json); ++i) {
                 cJSON *rel = cJSON_GetArrayItem(json, i);
                 cJSON *pre = cJSON_GetObjectItem(rel, "prerelease");
-                if (!cJSON_IsTrue(pre)) { release = rel; break; }
+                if (!cJSON_IsTrue(pre)) {
+                    release = rel;
+                    break;
+                }
             }
         }
     }
-    if (!release) { cJSON_Delete(json); ESP_LOGE(TAG, "No suitable release"); return ESP_FAIL; }
+    if (!release) {
+        cJSON_Delete(json);
+        ESP_LOGE(TAG, "No suitable release");
+        return ESP_FAIL;
+    }
     ESP_LOGD(TAG, "Release selected");
     cJSON *assets = cJSON_GetObjectItem(release, "assets");
-    if (!cJSON_IsArray(assets)) { cJSON_Delete(json); return ESP_FAIL; }
-    const char *fw=NULL,*sig=NULL;
+    if (!cJSON_IsArray(assets)) {
+        cJSON_Delete(json);
+        return ESP_FAIL;
+    }
+    const char *fw = NULL, *sig = NULL;
     cJSON *tag = cJSON_GetObjectItem(release, "tag_name");
     int relMaj, relMin, relPat;
-    bool relValid = parse_version(cJSON_IsString(tag)?tag->valuestring:NULL, &relMaj, &relMin, &relPat);
+    bool relValid = parse_version(cJSON_IsString(tag) ? tag->valuestring : NULL,
+                                  &relMaj, &relMin, &relPat);
     ESP_LOGI(TAG, "Latest release version %d.%d.%d", relMaj, relMin, relPat);
     if (!relValid) {
         ESP_LOGE(TAG, "Invalid release version, assuming 0.0.0");
     }
-    if (relValid && curValid && cmp_version(relMaj, relMin, relPat, curMaj, curMin, curPat) <= 0) {
+    if (relValid && curValid &&
+        cmp_version(relMaj, relMin, relPat, curMaj, curMin, curPat) <= 0) {
         ESP_LOGI(TAG, "Firmware already up to date");
         cJSON_Delete(json);
         return ESP_OK;
     }
     ESP_LOGD(TAG, "Scanning assets for firmware and signature");
-    for (int i=0;i<cJSON_GetArraySize(assets);++i){
-        cJSON *a = cJSON_GetArrayItem(assets,i);
-        cJSON *name = cJSON_GetObjectItem(a,"name");
-        cJSON *url = cJSON_GetObjectItem(a,"browser_download_url");
+    for (int i = 0; i < cJSON_GetArraySize(assets); ++i) {
+        cJSON *a = cJSON_GetArrayItem(assets, i);
+        cJSON *name = cJSON_GetObjectItem(a, "name");
+        cJSON *url = cJSON_GetObjectItem(a, "browser_download_url");
         if (cJSON_IsString(name) && cJSON_IsString(url)) {
-            if (!strcmp(name->valuestring, "main.bin")) fw = url->valuestring;
-            else if (!strcmp(name->valuestring, "main.bin.sig")) sig = url->valuestring;
+            if (!strcmp(name->valuestring, "main.bin"))
+                fw = url->valuestring;
+            else if (!strcmp(name->valuestring, "main.bin.sig"))
+                sig = url->valuestring;
         }
     }
-    if (!fw || !sig) { cJSON_Delete(json); ESP_LOGE(TAG, "Missing assets"); return ESP_FAIL; }
+    if (!fw || !sig) {
+        cJSON_Delete(json);
+        ESP_LOGE(TAG, "Missing assets");
+        return ESP_FAIL;
+    }
     ESP_LOGD(TAG, "Firmware URL: %s", fw);
     ESP_LOGD(TAG, "Signature URL: %s", sig);
-    ESP_LOGI(TAG, "Release %s selected", cJSON_IsString(tag)?tag->valuestring:"?");
-    led_breathing_start();
+    ESP_LOGI(TAG, "Release %s selected",
+             cJSON_IsString(tag) ? tag->valuestring : "?");
+    led_blinking_start();
     esp_err_t res = github_update_from_urls(fw, sig);
-    led_breathing_stop();
+    led_blinking_stop();
     ESP_LOGD(TAG, "github_update_from_urls -> %s", esp_err_to_name(res));
     cJSON_Delete(json);
     return res;

--- a/main/main.c
+++ b/main/main.c
@@ -8,29 +8,29 @@
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
-   The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
+   The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
 
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
 
    for more information visit https://www.studiopieters.nl
  **/
 
-#include <stdio.h>
+#include "github_update.h"
+#include <driver/gpio.h>
 #include <esp_log.h>
-#include <nvs_flash.h>
+#include <esp_sntp.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#include <driver/gpio.h>
+#include <nvs_flash.h>
+#include <stdio.h>
 #include <wifi_config.h>
-#include <esp_sntp.h>
-#include "github_update.h"
-#include <driver/ledc.h>
 
 // GPIO-definities
 #define BUTTON_GPIO CONFIG_ESP_BUTTON_GPIO
@@ -47,66 +47,64 @@ static bool led_enabled = false;
 static bool led_configured = false;
 static bool led_on = false;
 static TaskHandle_t led_task = NULL;
-static bool led_breathing = false;
+static bool led_blinking = false;
 
 void led_write(bool on) {
-    if (led_gpio < 0) return;
+    if (led_gpio < 0)
+        return;
     ESP_LOGD(TAG, "Setting LED %s", on ? "ON" : "OFF");
     gpio_set_level(led_gpio, on ? 1 : 0);
 }
 
-static void led_breath_task(void *pv) {
-    int duty = 0;
-    bool up = true;
-    ledc_timer_config_t tcfg = {
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .timer_num = LEDC_TIMER_0,
-        .duty_resolution = LEDC_TIMER_8_BIT,
-        .freq_hz = 5000,
-        .clk_cfg = LEDC_AUTO_CLK,
-    };
-    ledc_timer_config(&tcfg);
-    ledc_channel_config_t cconf = {
-        .gpio_num = led_gpio,
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .channel = LEDC_CHANNEL_0,
-        .intr_type = LEDC_INTR_DISABLE,
-        .timer_sel = LEDC_TIMER_0,
-        .duty = 0,
-        .hpoint = 0,
-    };
-    ledc_channel_config(&cconf);
-    while (led_breathing) {
-        ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, duty);
-        ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0);
-        vTaskDelay(pdMS_TO_TICKS(20));
-        if (up) {
-            duty++;
-            if (duty >= 255) { duty = 255; up = false; }
-        } else {
-            duty--;
-            if (duty <= 0) { duty = 0; up = true; }
-        }
+static void led_apply_idle_state(void) {
+    if (!led_enabled || led_gpio < 0) {
+        led_write(false);
+        return;
     }
-    ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, 0);
-    ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0);
+    led_write(led_on);
+}
+
+static void led_blink_task(void *pv) {
+    (void)pv;
+    const TickType_t half_period = pdMS_TO_TICKS(500);
+    TickType_t last_toggle = xTaskGetTickCount();
+
+    while (led_blinking) {
+        led_write(true);
+        vTaskDelayUntil(&last_toggle, half_period);
+        if (!led_blinking)
+            break;
+        led_write(false);
+        vTaskDelayUntil(&last_toggle, half_period);
+    }
+
+    led_write(false);
+    led_task = NULL;
     vTaskDelete(NULL);
 }
 
-void led_breathing_start() {
-    if (led_gpio < 0 || !led_enabled || led_breathing) return;
-    led_breathing = true;
-    xTaskCreate(led_breath_task, "led_breath", 2048, NULL, 5, &led_task);
+void led_blinking_start() {
+    if (led_gpio < 0 || !led_enabled || led_blinking)
+        return;
+    led_blinking = true;
+    BaseType_t rc =
+        xTaskCreate(led_blink_task, "led_blink", 2048, NULL, 5, &led_task);
+    if (rc != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create LED blink task");
+        led_task = NULL;
+        led_blinking = false;
+    }
 }
 
-void led_breathing_stop() {
-    if (!led_breathing) return;
-    led_breathing = false;
-    if (led_task) {
-        vTaskDelete(led_task);
-        led_task = NULL;
-    }
-    led_write(false);
+void led_blinking_stop() {
+    if (!led_blinking)
+        return;
+    led_blinking = false;
+    TaskHandle_t task = led_task;
+    led_task = NULL;
+    if (task)
+        vTaskDelete(task);
+    led_apply_idle_state();
 }
 
 void gpio_init() {
@@ -115,18 +113,16 @@ void gpio_init() {
     if (led_gpio >= 0) {
         gpio_reset_pin(led_gpio);
         gpio_set_direction(led_gpio, GPIO_MODE_OUTPUT);
-        led_write(led_on);
+        led_apply_idle_state();
         ESP_LOGD(TAG, "LED GPIO configured on pin %d", led_gpio);
     }
 
     // Knop setup
-    gpio_config_t io_conf = {
-        .pin_bit_mask = 1ULL << BUTTON_GPIO,
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE
-    };
+    gpio_config_t io_conf = {.pin_bit_mask = 1ULL << BUTTON_GPIO,
+                             .mode = GPIO_MODE_INPUT,
+                             .pull_up_en = GPIO_PULLUP_ENABLE,
+                             .pull_down_en = GPIO_PULLDOWN_DISABLE,
+                             .intr_type = GPIO_INTR_DISABLE};
     gpio_config(&io_conf);
     ESP_LOGD(TAG, "Button GPIO configured on pin %d", BUTTON_GPIO);
 }
@@ -148,16 +144,17 @@ void factory_reset_task(void *pvParameter) {
 
 void factory_reset() {
     ESP_LOGI("RESET", "Resetting device configuration");
-    if (xTaskCreate(factory_reset_task, "factory_reset", 4096, NULL, 2, NULL) != pdPASS) {
+    if (xTaskCreate(factory_reset_task, "factory_reset", 4096, NULL, 2, NULL) !=
+        pdPASS) {
         ESP_LOGE("RESET", "Failed to create factory_reset task");
     }
 }
 
 void led_config_update(bool enabled, int gpio) {
-    led_write(false);
     led_enabled = enabled;
+    led_on = enabled && gpio >= 0;
+    led_blinking_stop();
     led_gpio = gpio;
-    led_on = enabled;
     gpio_init();
 }
 
@@ -176,8 +173,10 @@ void button_task(void *pvParameter) {
                 press_start = xTaskGetTickCount();
                 pressed = true;
                 ESP_LOGD(TAG, "Button press detected");
-            } else if (xTaskGetTickCount() - press_start >= pdMS_TO_TICKS(RESET_HOLD_MS)) {
-                ESP_LOGW(TAG, "Button held for %dms → resetting configuration", RESET_HOLD_MS);
+            } else if (xTaskGetTickCount() - press_start >=
+                       pdMS_TO_TICKS(RESET_HOLD_MS)) {
+                ESP_LOGW(TAG, "Button held for %dms → resetting configuration",
+                         RESET_HOLD_MS);
                 factory_reset();
                 vTaskDelay(pdMS_TO_TICKS(1000));
                 pressed = false; // prevent retrigger before reboot
@@ -198,41 +197,46 @@ void app_main(void) {
         ESP_LOGE(TAG, "NVS init failed: %s", esp_err_to_name(err));
     }
     led_configured = load_led_config(&led_enabled, &led_gpio);
+    if (led_configured) {
+        led_on = led_enabled && led_gpio >= 0;
+    }
     gpio_init();
-    if (xTaskCreate(button_task, "button_task", 2048, NULL, 10, NULL) != pdPASS) {
+    if (xTaskCreate(button_task, "button_task", 2048, NULL, 10, NULL) !=
+        pdPASS) {
         ESP_LOGE(TAG, "Failed to create button task");
     }
     wifi_config_init("LCM", NULL, wifi_ready);
 }
 
-static void sntp_start_and_wait(void){
+static void sntp_start_and_wait(void) {
     ESP_LOGD(TAG, "Starting SNTP");
     esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
     esp_sntp_setservername(0, "pool.ntp.org");
     esp_sntp_init();
-    time_t now=0; struct tm tm={0};
-    for (int i=0; i<20 && tm.tm_year < (2016-1900); ++i) {
+    time_t now = 0;
+    struct tm tm = {0};
+    for (int i = 0; i < 20 && tm.tm_year < (2016 - 1900); ++i) {
         vTaskDelay(pdMS_TO_TICKS(500));
-        time(&now); localtime_r(&now, &tm);
-        ESP_LOGD(TAG, "SNTP attempt %d, year=%d", i, tm.tm_year+1900);
+        time(&now);
+        localtime_r(&now, &tm);
+        ESP_LOGD(TAG, "SNTP attempt %d, year=%d", i, tm.tm_year + 1900);
     }
     ESP_LOGD(TAG, "SNTP sync completed");
 }
 
-void wifi_ready(void)
-{
+void wifi_ready(void) {
     ESP_LOGI("app", "WiFi ready; starting OTA check");
     esp_log_level_set("*", ESP_LOG_INFO);
     esp_log_level_set("github_update", ESP_LOG_DEBUG);
     esp_log_level_set("esp_https_ota", ESP_LOG_DEBUG);
-    esp_log_level_set("HTTP_CLIENT",   ESP_LOG_DEBUG);
+    esp_log_level_set("HTTP_CLIENT", ESP_LOG_DEBUG);
 
     ESP_LOGI("app", "Starting SNTP synchronization");
     sntp_start_and_wait();
     ESP_LOGI("app", "SNTP synchronization complete");
 
-    char repo[96]={0};
-    bool pre=false;
+    char repo[96] = {0};
+    bool pre = false;
     if (!load_fw_config(repo, sizeof(repo), &pre)) {
         ESP_LOGW("app", "Geen firmware-config in NVS; configureer via web UI.");
         return;


### PR DESCRIPTION
## Summary
- add an idle-state helper and rework the blink task to use precise delays and clean up its task handle
- guard blink start/stop against failures, restore the configured idle LED state after updates, and stop blinking before reconfiguring pins
- apply the saved LED configuration on boot so the indicator returns to its configured steady state when idle

## Testing
- `idf.py build`


------
https://chatgpt.com/codex/tasks/task_e_68c6eea165fc832182d4b5da0bb13435