### PR TITLE
Add boot button reset handling to LED example

### DIFF
--- a/example/led/main/esp32-wifi.c
+++ b/example/led/main/esp32-wifi.c
@@ -183,3 +183,29 @@ esp_err_t wifi_stop(void) {
     if (r3 != ESP_OK) return r3;
     return ESP_OK;
 }
+
+esp_err_t wifi_reset_settings(void) {
+    ESP_LOGI(TAG, "WiFi-instellingen wissen uit NVS");
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open("wifi_cfg", NVS_READWRITE, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(TAG, "Geen opgeslagen WiFi-configuratie gevonden");
+        return ESP_OK;
+    } else if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Kon NVS-namespace 'wifi_cfg' niet openen: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    err = nvs_erase_all(handle);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+    nvs_close(handle);
+
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "WiFi-configuratie succesvol verwijderd");
+    } else {
+        ESP_LOGE(TAG, "Kon WiFi-configuratie niet verwijderen: %s", esp_err_to_name(err));
+    }
+    return err;
+}

--- a/example/led/main/esp32-wifi.h
+++ b/example/led/main/esp32-wifi.h
@@ -12,6 +12,10 @@ esp_err_t wifi_start(void (*on_ready)(void));
 // Optioneel: stop WiFi netjes
 esp_err_t wifi_stop(void);
 
+// Verwijder opgeslagen WiFi-instellingen uit NVS (wifi_cfg namespace).
+// Het is geen fout wanneer er geen opgeslagen configuratie aanwezig is.
+esp_err_t wifi_reset_settings(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- add boot button support with click, double-click, and long-press handling in the LED example
- reset HomeKit and Wi-Fi configuration through the button actions and restart the device
- expose a helper in the example Wi-Fi module to clear stored credentials

## Testing
- idf.py reconfigure

------
https://chatgpt.com/codex/tasks/task_e_68caeaca0f808321b6079c0eb79263b0