### PR TITLE
Update example firmware revision to match OTA version

### DIFF
--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -52,6 +52,10 @@ void lifecycle_factory_reset_and_reboot(void);
 esp_err_t lifecycle_init_firmware_revision(homekit_characteristic_t *revision,
                                            const char *fallback_version);
 
+// Retrieve the cached firmware revision string. Returns NULL if no revision
+// has been initialised yet.
+const char *lifecycle_get_firmware_revision_string(void);
+
 // Verwerk de custom HomeKit OTA trigger. Gebruik dit als setter van de characteristic.
 void lifecycle_handle_ota_trigger(homekit_characteristic_t *characteristic,
                                   homekit_value_t value);

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -26,6 +26,7 @@
 
 #include <esp_err.h>
 #include <esp_log.h>
+#include <string.h>
 #include <driver/gpio.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -45,7 +46,10 @@
 #ifndef CONFIG_APP_PROJECT_VER
 #define CONFIG_APP_PROJECT_VER "0.0.1"
 #endif
-#define FW_VERSION CONFIG_APP_PROJECT_VER
+
+static char fw_version_buffer[LIFECYCLE_FW_REVISION_MAX_LEN] = CONFIG_APP_PROJECT_VER;
+
+#define FW_VERSION fw_version_buffer
 
 static const char *HOMEKIT_TAG = "HOMEKIT";
 
@@ -156,6 +160,10 @@ void app_main(void) {
     ESP_ERROR_CHECK(lifecycle_nvs_init());
 
     esp_err_t rev_err = lifecycle_init_firmware_revision(&revision, FW_VERSION);
+    const char *resolved_version = lifecycle_get_firmware_revision_string();
+    if (resolved_version && resolved_version[0] != '\0') {
+        strlcpy(fw_version_buffer, resolved_version, sizeof(fw_version_buffer));
+    }
     if (rev_err != ESP_OK) {
         ESP_LOGW(HOMEKIT_TAG, "Firmware revision init failed: %s", esp_err_to_name(rev_err));
     }


### PR DESCRIPTION
## Summary
- track the cached OTA firmware revision in the lifecycle helper and expose an accessor so other code can read it
- update the HomeKit example to back the `FW_VERSION` macro with a mutable buffer and refresh it from the stored revision after initialization

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68cd82395a0c832182e028ff153b6cfc