### PR TITLE
Implement multi-press BOOT button handling

### DIFF
--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -56,6 +56,7 @@ void lifecycle_handle_ota_trigger(homekit_characteristic_t *characteristic,
 typedef enum {
     LIFECYCLE_BUTTON_EVENT_SINGLE = 0,
     LIFECYCLE_BUTTON_EVENT_DOUBLE,
+    LIFECYCLE_BUTTON_EVENT_TRIPLE,
     LIFECYCLE_BUTTON_EVENT_LONG,
 } lifecycle_button_event_t;
 
@@ -71,10 +72,11 @@ typedef void (*lifecycle_button_event_cb_t)(lifecycle_button_event_t event, void
 typedef struct {
     gpio_num_t gpio;
     uint32_t debounce_us;
-    uint32_t double_click_us;
+    uint32_t double_click_us; // Multi-press window (double/triple) in microseconds.
     uint32_t long_press_us;
     lifecycle_button_action_t single_action;
     lifecycle_button_action_t double_action;
+    lifecycle_button_action_t triple_action;
     lifecycle_button_action_t long_action;
     lifecycle_button_event_cb_t event_callback;
     void *event_context;

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -147,10 +147,6 @@ homekit_server_config_t config = {
     .setupId = CONFIG_ESP_SETUP_ID,
 };
 
-static void ota_trigger_setter(homekit_characteristic_t *ch, homekit_value_t value) {
-    lifecycle_handle_ota_trigger(ch, value);
-}
-
 static void on_wifi_ready(void) {
     ESP_LOGI(HOMEKIT_TAG, "Starting HomeKit server...");
     homekit_server_init(&config);
@@ -177,7 +173,7 @@ void app_main(void) {
     }
 
     ota_trigger.setter = NULL;
-    ota_trigger.setter_ex = ota_trigger_setter;
+    ota_trigger.setter_ex = lifecycle_handle_ota_trigger;
     ota_trigger.value.bool_value = false;
 
     gpio_reset_pin(LED_GPIO);
@@ -186,8 +182,9 @@ void app_main(void) {
 
     const lifecycle_button_config_t button_cfg = {
         .gpio = BUTTON_GPIO,
-        .single_action = LIFECYCLE_BUTTON_ACTION_REQUEST_UPDATE,
-        .double_action = LIFECYCLE_BUTTON_ACTION_RESET_HOMEKIT,
+        .single_action = LIFECYCLE_BUTTON_ACTION_NONE,
+        .double_action = LIFECYCLE_BUTTON_ACTION_REQUEST_UPDATE,
+        .triple_action = LIFECYCLE_BUTTON_ACTION_RESET_HOMEKIT,
         .long_action = LIFECYCLE_BUTTON_ACTION_FACTORY_RESET,
     };
     ESP_ERROR_CHECK(lifecycle_button_init(&button_cfg));

--- a/main/github_update.c
+++ b/main/github_update.c
@@ -17,6 +17,10 @@
 
 static const char *TAG = "github_update";
 
+#ifndef ESP_PARTITION_LABEL_MAX_LEN
+#define ESP_PARTITION_LABEL_MAX_LEN 16
+#endif
+
 #define INSTALLED_VER_MAX_LEN 32
 #define INSTALLED_PART_KEY "installed_part"
 #define INSTALLED_LABEL_MAX_LEN (ESP_PARTITION_LABEL_MAX_LEN + 1)

--- a/main/main.c
+++ b/main/main.c
@@ -29,18 +29,38 @@
 #include <driver/gpio.h>
 #include <wifi_config.h>
 #include <esp_sntp.h>
+#include <esp_system.h>
+#include <esp_wifi.h>
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
+#include <nvs.h>
 #include "github_update.h"
 #include "led_indicator.h"
+
+#if defined(__has_include)
+#if __has_include(<homekit/homekit.h>)
+#include <homekit/homekit.h>
+#define LCM_HAVE_HOMEKIT 1
+#else
+#define LCM_HAVE_HOMEKIT 0
+#endif
+#else
+#define LCM_HAVE_HOMEKIT 0
+#endif
 
 // GPIO-definities
 #define BUTTON_GPIO CONFIG_ESP_BUTTON_GPIO
 #define DEBOUNCE_TIME_MS 50
 #define RESET_HOLD_MS 3000
+#define MULTI_CLICK_TIMEOUT_MS 400
 
 static const char *TAG = "main";
 
 static void sntp_start_and_wait(void);
 void wifi_ready(void);
+static void handle_button_press_count(int count);
+static void request_lcm_update(void);
+static void reset_homekit(void);
 
 static int led_gpio = CONFIG_ESP_LED_GPIO;
 static bool led_enabled = true;
@@ -124,10 +144,39 @@ void gpio_init() {
     ESP_LOGD(TAG, "Button GPIO configured on pin %d", BUTTON_GPIO);
 }
 
+static bool factory_reset_requested = false;
+
+static void clear_nvs_storage(void) {
+    esp_err_t err = nvs_flash_deinit();
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_INITIALIZED) {
+        ESP_LOGW("RESET", "nvs_flash_deinit failed: %s", esp_err_to_name(err));
+    }
+
+    err = nvs_flash_erase();
+    if (err != ESP_OK) {
+        ESP_LOGE("RESET", "nvs_flash_erase failed: %s", esp_err_to_name(err));
+    } else {
+        ESP_LOGI("RESET", "NVS flash erased");
+    }
+
+    err = nvs_flash_init();
+    if (err != ESP_OK) {
+        ESP_LOGW("RESET", "nvs_flash_init after erase failed: %s", esp_err_to_name(err));
+    }
+}
+
 // Task factory_reset
 void factory_reset_task(void *pvParameter) {
-    ESP_LOGI("RESET", "Resetting WiFi Config");
-    wifi_config_reset();
+    ESP_LOGI("RESET", "Performing factory reset (clearing WiFi and NVS)");
+
+    esp_err_t wifi_err = esp_wifi_restore();
+    if (wifi_err != ESP_OK) {
+        ESP_LOGW("RESET", "esp_wifi_restore failed: %s", esp_err_to_name(wifi_err));
+    } else {
+        ESP_LOGI("RESET", "WiFi configuration restored to defaults");
+    }
+
+    clear_nvs_storage();
 
     ESP_LOGD("RESET", "Waiting before reboot");
     vTaskDelay(pdMS_TO_TICKS(1000));
@@ -135,45 +184,177 @@ void factory_reset_task(void *pvParameter) {
     ESP_LOGI("RESTART", "Restarting system");
     esp_restart();
 
+    factory_reset_requested = false;
     ESP_LOGD("RESET", "factory_reset_task completed");
     vTaskDelete(NULL);
 }
 
 void factory_reset() {
+    if (factory_reset_requested) {
+        ESP_LOGW("RESET", "Factory reset already in progress");
+        return;
+    }
+
     ESP_LOGI("RESET", "Resetting device configuration");
     if (xTaskCreate(factory_reset_task, "factory_reset", 4096, NULL, 2, NULL) != pdPASS) {
         ESP_LOGE("RESET", "Failed to create factory_reset task");
+    } else {
+        factory_reset_requested = true;
     }
+}
+
+static void handle_button_press_count(int count) {
+    if (count <= 0) {
+        return;
+    }
+
+    if (count == 1) {
+        ESP_LOGI(TAG, "Single press detected (no action)");
+        return;
+    }
+
+    if (count == 2) {
+        ESP_LOGI(TAG, "Double press detected → request firmware update through LCM");
+        request_lcm_update();
+        return;
+    }
+
+    ESP_LOGI(TAG, "Triple press detected → reset HomeKit");
+    reset_homekit();
 }
 
 // Task button
 void button_task(void *pvParameter) {
     ESP_LOGI(TAG, "Button task started");
-    bool pressed = false;
-    TickType_t press_start = 0;
+    const TickType_t debounce_ticks = pdMS_TO_TICKS(DEBOUNCE_TIME_MS);
+    const TickType_t long_press_ticks = pdMS_TO_TICKS(RESET_HOLD_MS);
+    const TickType_t multi_timeout_ticks = pdMS_TO_TICKS(MULTI_CLICK_TIMEOUT_MS);
+
+    bool stable_state = gpio_get_level(BUTTON_GPIO) == 0;
+    bool raw_state = stable_state;
+    TickType_t last_raw_change = xTaskGetTickCount();
+    TickType_t press_start = stable_state ? last_raw_change : 0;
+    bool long_press_triggered = false;
+    int press_count = 0;
+    TickType_t last_release_tick = 0;
+    bool waiting_for_multi = false;
 
     while (1) {
-        bool state = gpio_get_level(BUTTON_GPIO) == 0; // active low
-        ESP_LOGD(TAG, "Button state: %d", state);
+        TickType_t now = xTaskGetTickCount();
 
-        if (state) {
-            if (!pressed) {
-                press_start = xTaskGetTickCount();
-                pressed = true;
-                ESP_LOGD(TAG, "Button press detected");
-            } else if (xTaskGetTickCount() - press_start >= pdMS_TO_TICKS(RESET_HOLD_MS)) {
-                ESP_LOGW(TAG, "Button held for %dms → resetting configuration", RESET_HOLD_MS);
-                factory_reset();
-                vTaskDelay(pdMS_TO_TICKS(1000));
-                pressed = false; // prevent retrigger before reboot
-            }
-        } else if (pressed) {
-            pressed = false;
-            ESP_LOGD(TAG, "Button released");
+        if (waiting_for_multi && (now - last_release_tick) > multi_timeout_ticks) {
+            handle_button_press_count(press_count);
+            press_count = 0;
+            waiting_for_multi = false;
         }
 
-        vTaskDelay(pdMS_TO_TICKS(DEBOUNCE_TIME_MS));
+        bool current_raw = gpio_get_level(BUTTON_GPIO) == 0;
+        if (current_raw != raw_state) {
+            raw_state = current_raw;
+            last_raw_change = now;
+        }
+
+        if (stable_state != raw_state && (now - last_raw_change) >= debounce_ticks) {
+            stable_state = raw_state;
+            if (stable_state) {
+                press_start = now;
+                long_press_triggered = false;
+            } else {
+                if (!long_press_triggered) {
+                    TickType_t press_duration = now - press_start;
+                    if (press_duration >= long_press_ticks) {
+                        long_press_triggered = true;
+                        press_count = 0;
+                        waiting_for_multi = false;
+                        ESP_LOGW(TAG, "Long press detected → resetting configuration");
+                        factory_reset();
+                    } else {
+                        if (press_count < 255) {
+                            press_count++;
+                        }
+                        if (press_count >= 3) {
+                            handle_button_press_count(press_count);
+                            press_count = 0;
+                            waiting_for_multi = false;
+                        } else {
+                            waiting_for_multi = true;
+                            last_release_tick = now;
+                        }
+                    }
+                }
+            }
+        } else if (stable_state && !long_press_triggered) {
+            TickType_t held = now - press_start;
+            if (held >= long_press_ticks) {
+                long_press_triggered = true;
+                press_count = 0;
+                waiting_for_multi = false;
+                ESP_LOGW(TAG, "Long press detected → resetting configuration");
+                factory_reset();
+            }
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
+}
+
+static void request_lcm_update(void) {
+    ESP_LOGI(TAG, "Setting update request flag for Lifecycle Manager");
+
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open("lcm", NVS_READWRITE, &handle);
+    bool update_flag_set = false;
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS namespace 'lcm': %s", esp_err_to_name(err));
+    } else {
+        err = nvs_set_u8(handle, "do_update", 1);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set update flag: %s", esp_err_to_name(err));
+        } else {
+            err = nvs_commit(handle);
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to commit update flag: %s", esp_err_to_name(err));
+            } else {
+                ESP_LOGI(TAG, "Lifecycle Manager will run on next boot to install firmware");
+                update_flag_set = true;
+            }
+        }
+        nvs_close(handle);
+    }
+
+    if (!update_flag_set) {
+        ESP_LOGW(TAG, "Update flag could not be stored; aborting reboot to Lifecycle Manager");
+        return;
+    }
+
+    const esp_partition_t *factory = esp_partition_find_first(
+            ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_APP_FACTORY, NULL);
+    if (!factory) {
+        ESP_LOGE(TAG, "Factory partition not found; cannot hand off to Lifecycle Manager");
+        return;
+    }
+
+    err = esp_ota_set_boot_partition(factory);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set factory partition for boot: %s", esp_err_to_name(err));
+        return;
+    }
+
+    ESP_LOGI(TAG, "Rebooting into Lifecycle Manager to perform update");
+    vTaskDelay(pdMS_TO_TICKS(100));
+    esp_restart();
+}
+
+static void reset_homekit(void) {
+#if LCM_HAVE_HOMEKIT
+    ESP_LOGI(TAG, "Resetting HomeKit pairing information");
+    homekit_server_reset();
+    vTaskDelay(pdMS_TO_TICKS(100));
+    ESP_LOGI(TAG, "Rebooting after HomeKit reset");
+    esp_restart();
+#else
+    ESP_LOGW(TAG, "HomeKit reset requested, but HomeKit support is not available");
+#endif
 }
 
 void app_main(void) {


### PR DESCRIPTION
## Summary
- add multi-press handling for the BOOT button to trigger Lifecycle Manager update, HomeKit reset, or factory reset that wipes NVS
- guard optional HomeKit support and request-update flow with new helpers and improved logging
- provide a fallback definition for ESP_PARTITION_LABEL_MAX_LEN for newer ESP-IDF compatibility

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68ce92c090208321a84ef6ad25f82066