### PR TITLE
Update lifecycle button GPIO

### DIFF
--- a/example/led/README.md
+++ b/example/led/README.md
@@ -37,7 +37,7 @@ Connect `LED` pin to the following pin:
 
 ## BOOT button actions
 
-The BOOT button (GPIO0, active low) controls the device lifecycle without reflashing:
+The BOOT button (GPIO33, active low to GND) controls the device lifecycle without reflashing:
 
 - **Single press (<0.4 s):** Flag the Lifecycle Manager (LCM) update in NVS, boot the factory partition and let the LCM perform the OTA update before rebooting into the new firmware.
 - **Double press (two clicks within 400 ms):** Reset HomeKit pairing information via `homekit_server_reset()` and reboot so the accessory can be paired again.

--- a/example/led/README.md
+++ b/example/led/README.md
@@ -17,6 +17,7 @@ Connect `LED` pin to the following pin:
 | Name | Description | Defaults |
 |------|-------------|----------|
 | `CONFIG_ESP_LED_GPIO` | GPIO number for `LED` pin | "2" Default |
+| `CONFIG_ESP_BUTTON_GPIO` | GPIO for lifecycle button (active low to GND) | "33" Default |
 
 ## Scheme
 

--- a/example/led/README.md
+++ b/example/led/README.md
@@ -37,7 +37,7 @@ Connect `LED` pin to the following pin:
 
 ## BOOT button actions
 
-The BOOT button (GPIO33, active low to GND) controls the device lifecycle without reflashing:
+The BOOT button (`CONFIG_ESP_BUTTON_GPIO`, default GPIO33 and active low to GND) controls the device lifecycle without reflashing:
 
 - **Single press (<0.4 s):** Flag the Lifecycle Manager (LCM) update in NVS, boot the factory partition and let the LCM perform the OTA update before rebooting into the new firmware.
 - **Double press (two clicks within 400 ms):** Reset HomeKit pairing information via `homekit_server_reset()` and reboot so the accessory can be paired again.

--- a/example/led/main/Kconfig.projbuild
+++ b/example/led/main/Kconfig.projbuild
@@ -6,6 +6,12 @@ menu "StudioPieters"
               help
                   The GPIO number the LED is connected to.
 
+      config ESP_BUTTON_GPIO
+              int "Set the GPIO for the lifecycle button"
+              default 33
+              help
+                  The GPIO number for the lifecycle button connected to ground.
+
       config ESP_SETUP_CODE
               string "HomeKit Setup Code"
               default "338-77-883"

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -35,7 +35,9 @@
 
 #include "esp32-lcm.h"
 
-#define BUTTON_GPIO GPIO_NUM_0
+// Boot/lifecycle button wired to ground, so keep the internal pull-up enabled
+// and treat a LOW level as a pressed state.
+#define BUTTON_GPIO GPIO_NUM_33
 #define LED_GPIO CONFIG_ESP_LED_GPIO
 
 #define DEVICE_NAME "HomeKit LED"

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -37,7 +37,7 @@
 
 // Boot/lifecycle button wired to ground, so keep the internal pull-up enabled
 // and treat a LOW level as a pressed state.
-#define BUTTON_GPIO GPIO_NUM_33
+#define BUTTON_GPIO CONFIG_ESP_BUTTON_GPIO
 #define LED_GPIO CONFIG_ESP_LED_GPIO
 
 #define DEVICE_NAME "HomeKit LED"
@@ -189,7 +189,15 @@ void app_main(void) {
         .triple_action = LIFECYCLE_BUTTON_ACTION_RESET_HOMEKIT,
         .long_action = LIFECYCLE_BUTTON_ACTION_FACTORY_RESET,
     };
+    ESP_LOGI(HOMEKIT_TAG,
+             "Configuring lifecycle button on GPIO %d (active low to GND)",
+             button_cfg.gpio);
     ESP_ERROR_CHECK(lifecycle_button_init(&button_cfg));
+
+    int button_level = gpio_get_level(BUTTON_GPIO);
+    ESP_LOGI(HOMEKIT_TAG,
+             "Lifecycle button initial level: %s (0=pressed, 1=released)",
+             button_level == 0 ? "pressed" : "released");
 
     ESP_ERROR_CHECK(wifi_start(on_wifi_ready));
 }


### PR DESCRIPTION
## Summary
- switch the lifecycle button definition to use GPIO33 instead of GPIO0
- document the new active-low-to-GND wiring for the button in the LED example README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceafc9542083219f04a474f46fbbea