### PR TITLE
Add detailed diagnostics for lifecycle button

### DIFF
--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -220,6 +220,8 @@ void app_main(void) {
     ESP_LOGI(HOMEKIT_TAG,
              "Configuring lifecycle button on GPIO %d (active low to GND)",
              button_cfg.gpio);
+    ESP_LOGI(HOMEKIT_TAG,
+             "Lifecycle button mapping: single=idle, double=LCM update, triple=HomeKit reset, long=factory reset");
     ESP_ERROR_CHECK(lifecycle_button_init(&button_cfg));
 
     int button_level = gpio_get_level(BUTTON_GPIO);


### PR DESCRIPTION
## Summary
- capture ISR timestamp, level, and edge data in lifecycle_button_isr_event_t and add extensive logging/counters in the button task and dispatcher for easier debugging of press handling
- log button configuration, GPIO levels, and action mappings during lifecycle_button_init to validate wiring at startup
- wire the application to report lifecycle button events through an event callback for immediate feedback when presses are detected

## Testing
- `idf.py -C example/led build`


------
https://chatgpt.com/codex/tasks/task_e_68cebd63b62083218ae359a8de1ef1fb