### PR TITLE
Fix Wi-Fi startup in LED example

### DIFF
--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -132,8 +132,8 @@ void on_wifi_ready() {
 void app_main(void) {
 
         ESP_ERROR_CHECK(lifecycle_nvs_init()); // Add this line
-        (void)lifecycle_configure_homekit(&revision, &ota_trigger); // Add this line
+        (void)lifecycle_configure_homekit(&revision, &ota_trigger, NULL); // Add this line
 
-        wifi_init();
+        ESP_ERROR_CHECK(wifi_start(on_wifi_ready));
         gpio_init();
 }


### PR DESCRIPTION
## Summary
- start the LED example Wi-Fi stack through the lifecycle manager helper
- pass the log tag argument when configuring lifecycle HomeKit support

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68d25aec94fc8321a87bb5ed2a68b5ec