### PR TITLE
Fix firmware signing script path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,20 @@
 ## Signing firmware
 
 After building your firmware, generate a `main.bin.sig` file containing the
-SHA-384 hash of the image followed by its length in bytes. From the directory
-where `make` is run execute:
+SHA-384 hash of the image followed by its length in bytes by running the helper
+script:
 
 ```bash
-openssl sha384 -binary -out build/main.bin.sig build/main.bin
-printf "%08x" `cat build/main.bin | wc -c` | xxd -r -p >> build/main.bin.sig
+./generate_sig.sh [path/to/build_or_main.bin]
 ```
 
-The resulting `build/main.bin.sig` must accompany `build/main.bin` when
-publishing releases. During an OTA update the device downloads both files,
-computes the SHA-384 hash of the image, checks the expected length, and
-activates the update only if they match.
+When no argument is supplied the script expects the ESP-IDF artefacts inside
+`build/` and operates on `build/main.bin`, producing `build/main.bin.sig`. You
+may also pass a different build directory (for example `./generate_sig.sh
+example/build`) or the explicit path to a `main.bin` image. The resulting
+`main.bin.sig` must accompany the image when publishing releases. During an OTA
+update the device downloads both files, computes the SHA-384 hash of the image,
+checks the expected length, and activates the update only if they match.
 
 ## OTA verification
 

--- a/generate_sig.sh
+++ b/generate_sig.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
-# Generate firmware/main.bin.sig containing SHA-384 hash and image length.
+# Generate a main.bin.sig file containing SHA-384 hash and image length.
 set -eu
-if [ ! -f firmware/main.bin ]; then
-  echo "firmware/main.bin not found" >&2
+
+TARGET_PATH="${1:-build/main.bin}"
+
+if [ -d "$TARGET_PATH" ]; then
+  TARGET_PATH="${TARGET_PATH%/}/main.bin"
+fi
+
+if [ ! -f "$TARGET_PATH" ]; then
+  echo "Firmware image not found: $TARGET_PATH" >&2
   exit 1
 fi
-openssl sha384 -binary -out firmware/main.bin.sig firmware/main.bin
-printf "%08x" $(wc -c < firmware/main.bin) | xxd -r -p >> firmware/main.bin.sig
+
+SIGNATURE_PATH="$TARGET_PATH.sig"
+
+openssl sha384 -binary -out "$SIGNATURE_PATH" "$TARGET_PATH"
+printf "%08x" "$(wc -c < "$TARGET_PATH")" | xxd -r -p >> "$SIGNATURE_PATH"


### PR DESCRIPTION
## Summary
- update the signing helper to default to build/main.bin and accept a custom firmware path or build directory
- refresh the README instructions to reference the script and explain its usage

## Testing
- ./generate_sig.sh

------
https://chatgpt.com/codex/tasks/task_e_68d25aed58248321aa887b714ac74291