### PR TITLE
Use lifecycle manager actions for button events

### DIFF
--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -87,7 +87,7 @@ void button_callback(button_event_t event, void *context) {
         switch (event) {
         case button_event_single_press:
                 ESP_LOGI("BUTTON", "Single press");
-                // LCM Update
+                lifecycle_request_update_and_reboot();
                 break;
         case button_event_double_press:
                 ESP_LOGI("BUTTON", "Double press");
@@ -95,7 +95,7 @@ void button_callback(button_event_t event, void *context) {
                 break;
         case button_event_long_press:
                 ESP_LOGI("BUTTON", "Long press");
-                //Factory Reset, clean all NVS settings.
+                lifecycle_factory_reset_and_reboot();
                 break;
         default:
                 ESP_LOGI("BUTTON", "Unknown button event: %d", event);


### PR DESCRIPTION
## Summary
- invoke the lifecycle manager update helper when the button is single-pressed
- trigger the lifecycle manager factory reset helper for long button presses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2d2a57b3083218a62dae0dbf14a76