### PR TITLE
Handle missing Wi-Fi credentials and fix OTA trigger

### DIFF
--- a/example/led/main/esp32-lcm.c
+++ b/example/led/main/esp32-lcm.c
@@ -159,7 +159,10 @@ esp_err_t wifi_start(void (*on_ready)(void)) {
     char *ssid = NULL;
     char *pass = NULL;
     esp_err_t err = nvs_load_wifi(&ssid, &pass);
-    if (err != ESP_OK) {
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(WIFI_TAG, "WiFi configuratie niet gevonden in NVS; provisioning vereist");
+        return err;
+    } else if (err != ESP_OK) {
         ESP_LOGE(WIFI_TAG, "Kon WiFi config niet laden uit NVS");
         return err;
     }
@@ -329,7 +332,7 @@ const char *lifecycle_get_firmware_revision_string(void) {
 }
 
 void lifecycle_handle_ota_trigger(homekit_characteristic_t *characteristic,
-                                  homekit_value_t value) {
+                                  const homekit_value_t value) {
     if (characteristic == NULL) {
         return;
     }

--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -60,7 +60,7 @@ const char *lifecycle_get_firmware_revision_string(void);
 
 // Verwerk de custom HomeKit OTA trigger. Gebruik dit als setter van de characteristic.
 void lifecycle_handle_ota_trigger(homekit_characteristic_t *characteristic,
-                                  homekit_value_t value);
+                                  const homekit_value_t value);
 
 // Initialise the HomeKit-facing lifecycle characteristics using defaults and
 // stored NVS values. Logs using the provided tag (falls back to the lifecycle

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -23,6 +23,8 @@
 
 #include <stdio.h>
 #include <esp_log.h>
+#include <esp_err.h>
+#include <nvs.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <driver/gpio.h>
@@ -168,5 +170,10 @@ void app_main(void) {
                 ESP_LOGE("BUTTON", "Failed to initialize button");  // Add this line
         }
 
-        ESP_ERROR_CHECK(wifi_start(on_wifi_ready));  // Add this line
+        esp_err_t wifi_err = wifi_start(on_wifi_ready);
+        if (wifi_err == ESP_ERR_NVS_NOT_FOUND) {
+                ESP_LOGW("WIFI", "Geen opgeslagen WiFi-configuratie gevonden; wacht op provisioning");
+        } else if (wifi_err != ESP_OK) {
+                ESP_LOGE("WIFI", "WiFi start mislukt: %s", esp_err_to_name(wifi_err));
+        }
 }


### PR DESCRIPTION
## Summary
- allow wifi_start() to return gracefully when no saved credentials are present and log a provisioning warning
- adjust the lifecycle OTA trigger handler signature to match HomeKit expectations
- guard the example app's Wi-Fi start call to avoid aborting on missing credentials and log failures clearly

## Testing
- idf.py build (example/led)


------
https://chatgpt.com/codex/tasks/task_e_68d41a36265083219d77638958beb7c0