### PR TITLE
Handle wifi_start error in LED example

### DIFF
--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -171,4 +171,9 @@ void app_main(void) {
         }
 
         esp_err_t wifi_err = wifi_start(on_wifi_ready); // Add this line
+        if (wifi_err == ESP_ERR_NVS_NOT_FOUND) {
+                ESP_LOGW("WIFI", "WiFi configuration not found; provisioning required");
+        } else if (wifi_err != ESP_OK) {
+                ESP_LOGE("WIFI", "Failed to start WiFi: %s", esp_err_to_name(wifi_err));
+        }
 }


### PR DESCRIPTION
## Summary
- handle the result of `wifi_start` in the LED example and log provisioning guidance or failures

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68d5507e91bc8321987d7979eab0d865