### PR TITLE
Start LED blinking earlier during firmware checks

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -216,6 +216,7 @@ void wifi_ready(void)
         return;
     }
     ESP_LOGI("app", "Firmware config loaded: repo=%s pre=%d", repo, pre);
+    led_blinking_start();
     ESP_LOGI("app", "Checking for firmware update");
     github_update_if_needed(repo, pre);
     led_blinking_stop();


### PR DESCRIPTION
## Summary
- start the LED blinking as soon as the firmware update check begins so the user sees activity before downloads start

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d571f411148321a58ec4484c7f85ab