### PR TITLE
Fix factory firmware version metadata and HomeKit init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,30 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(DEFAULT_FW_VERSION "0.0.2")
-set(PROJECT_VER "${DEFAULT_FW_VERSION}")
+set(PROJECT_BASE_VERSION "${DEFAULT_FW_VERSION}")
+
+execute_process(
+    COMMAND git describe --tags --abbrev=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_TAG
+    ERROR_QUIET
+    RESULT_VARIABLE GIT_TAG_RESULT
+)
+
+if(GIT_TAG_RESULT EQUAL 0)
+    string(STRIP "${GIT_TAG}" GIT_TAG_STRIPPED)
+    if(GIT_TAG_STRIPPED)
+        set(_semver_match "")
+        string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+$" _semver_match "${GIT_TAG_STRIPPED}")
+        if(_semver_match)
+            set(PROJECT_BASE_VERSION "${GIT_TAG_STRIPPED}")
+        else()
+            message(WARNING "Ignoring non-semver git tag '${GIT_TAG_STRIPPED}' for PROJECT_VER")
+        endif()
+    endif()
+endif()
+
+set(PROJECT_VER "${PROJECT_BASE_VERSION}")
 
 execute_process(
     COMMAND git rev-parse --short HEAD
@@ -14,7 +37,7 @@ execute_process(
 if(GIT_HASH_RESULT EQUAL 0)
     string(STRIP "${GIT_COMMIT_HASH}" GIT_COMMIT_HASH_STRIPPED)
     if(GIT_COMMIT_HASH_STRIPPED)
-        set(PROJECT_VER "${DEFAULT_FW_VERSION}+${GIT_COMMIT_HASH_STRIPPED}")
+        set(PROJECT_VER "${PROJECT_BASE_VERSION}+${GIT_COMMIT_HASH_STRIPPED}")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 
+set(DEFAULT_FW_VERSION "0.0.2")
+set(PROJECT_VER "${DEFAULT_FW_VERSION}")
+
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    ERROR_QUIET
+    RESULT_VARIABLE GIT_HASH_RESULT
+)
+
+if(GIT_HASH_RESULT EQUAL 0)
+    string(STRIP "${GIT_COMMIT_HASH}" GIT_COMMIT_HASH_STRIPPED)
+    if(GIT_COMMIT_HASH_STRIPPED)
+        set(PROJECT_VER "${DEFAULT_FW_VERSION}+${GIT_COMMIT_HASH_STRIPPED}")
+    endif()
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(esp32-lifecycle-manager)

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -39,6 +39,7 @@
 
 // LED control
 #define LED_GPIO CONFIG_ESP_LED_GPIO
+static const char *LED_TAG = "LED";
 bool led_on = false;
 
 void led_write(bool on) {
@@ -82,6 +83,7 @@ void led_on_set(homekit_value_t value) {
                 return;
         }
         led_on = value.bool_value;
+        ESP_LOGI(LED_TAG, "Setting LED %s", led_on ? "ON" : "OFF");
         led_write(led_on);
 }
 
@@ -152,8 +154,16 @@ homekit_server_config_t config = {
 };
 
 void on_wifi_ready() {
+        static bool homekit_started = false;
+
+        if (homekit_started) {
+                ESP_LOGI("INFORMATION", "HomeKit server already running; skipping re-initialization");
+                return;
+        }
+
         ESP_LOGI("INFORMATION", "Starting HomeKit server...");
         homekit_server_init(&config);
+        homekit_started = true;
 }
 
 void app_main(void) {


### PR DESCRIPTION
## Summary
- generate a semver-compatible PROJECT_VER that includes the current git hash when available
- log HomeKit LED characteristic updates and prevent duplicate server initialization after Wi-Fi events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c09d8ed88321b4f7224fcf9d81a8