### PR TITLE
Improve lifecycle reset sequencing and OTA handling

### DIFF
--- a/example/led/main/CMakeLists.txt
+++ b/example/led/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
     SRCS "main.c" "esp32-lcm.c"
-    REQUIRES freertos esp_wifi esp_event esp_netif nvs_flash driver esp32-homekit esp_timer app_update spi_flash esp_system
+    REQUIRES freertos esp_wifi esp_event esp_netif nvs_flash driver esp32-homekit esp_timer app_update spi_flash esp_system espressif__mdns
 )

--- a/example/led/main/esp32-lcm.h
+++ b/example/led/main/esp32-lcm.h
@@ -42,6 +42,15 @@
 extern "C" {
 #endif
 
+typedef enum {
+    LIFECYCLE_POST_RESET_NONE = 0,
+    LIFECYCLE_POST_RESET_REASON_HOMEKIT = 1,
+    LIFECYCLE_POST_RESET_REASON_FACTORY = 2,
+    LIFECYCLE_POST_RESET_REASON_UPDATE = 3,
+} lifecycle_post_reset_reason_t;
+
+void lifecycle_log_post_reset_state(const char *log_tag);
+
 // Initialiseer NVS en voer automatische herstelactie uit wanneer er geen ruimte is of versie verandert.
 esp_err_t lifecycle_nvs_init(void);
 

--- a/example/led/main/main.c
+++ b/example/led/main/main.c
@@ -168,6 +168,7 @@ void on_wifi_ready() {
 
 void app_main(void) {
         ESP_ERROR_CHECK(lifecycle_nvs_init());  // Add this line
+        lifecycle_log_post_reset_state("INFORMATION");
         ESP_ERROR_CHECK(lifecycle_configure_homekit(&revision, &ota_trigger, "INFORMATION"));  // Add this line
 
         gpio_init();

--- a/main/include/wifi_config.h
+++ b/main/include/wifi_config.h
@@ -15,3 +15,5 @@ void wifi_config_set(const char *ssid, const char *password);
 void wifi_config_set_custom_html(char *html);
 
 esp_err_t safe_set_auto_connect(bool enable);
+
+void wifi_config_shutdown(void);

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -1254,5 +1254,29 @@ void wifi_config_set_custom_html(char *html) {
         context->custom_html = html;
 }
 
+void wifi_config_shutdown(void) {
+        if (!context) {
+                DEBUG("wifi_config_shutdown called before initialization; nothing to do");
+                return;
+        }
+
+        INFO("Shutting down WiFi provisioning services");
+
+        wifi_config_softap_stop();
+
+        if (context->monitor_task_handle) {
+                vTaskDelete(context->monitor_task_handle);
+                context->monitor_task_handle = NULL;
+        }
+
+        if (context->network_monitor_timer) {
+                xTimerStop(context->network_monitor_timer, 0);
+                xTimerDelete(context->network_monitor_timer, 0);
+                context->network_monitor_timer = NULL;
+        }
+
+        INFO("WiFi provisioning services stopped");
+}
+
 
 __attribute__((used)) static void *linker_keep_client_send_index = (void *)&client_send_index;


### PR DESCRIPTION
## Summary
- record post-reset reasons and shut down HomeKit, mDNS, provisioning, and Wi-Fi in order before rebooting
- add a provisioning shutdown helper and mdns dependency, plus log the post-reset flag on boot
- debounce OTA boot partition selection to avoid redundant reboots

## Testing
- `idf.py -C example/led build`


------
https://chatgpt.com/codex/tasks/task_e_68d7ad574fac8321b109b7a01f010c6d