### PR TITLE
Set factory firmware version to 0.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-set(DEFAULT_FW_VERSION "0.0.2")
+set(DEFAULT_FW_VERSION "0.0.0")
 set(PROJECT_BASE_VERSION "${DEFAULT_FW_VERSION}")
 
 execute_process(


### PR DESCRIPTION
## Summary
- set the default firmware version constant to 0.0.0 so factory builds report the correct base version

## Testing
- `ninja -C build`


------
https://chatgpt.com/codex/tasks/task_e_68d8fbde7b0c8321b7ee56632e7ec817