### PR TITLE
Adjust power-cycle factory reset tolerance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ device to verify the firmware before applying it.
 
 ## Consecutive restart factory reset window
 
-The Lifecycle Manager performs a factory reset after detecting 10 consecutive
-restarts. The restarts must all occur within the configurable
+The Lifecycle Manager performs a factory reset after detecting between 10 and
+12 consecutive restarts. The restarts must all occur within the configurable
 `CONFIG_LCM_RESTART_COUNTER_TIMEOUT_MS` window (60 seconds by default). If the
 device runs longer than that window without restarting, the counter resets and
-the sequence must be repeated from the beginning. After the tenth restart, the
-device enters an on-device countdown that lasts roughly 11 seconds before the
-factory reset routine runs. Make sure to leave the device powered on during
-this countdown; toggling power again during this period prevents the
-`lifecycle_factory_reset_and_reboot()` helper from executing.
+the sequence must be repeated from the beginning. Once the restart counter
+reaches the configured window, the device enters an on-device countdown that
+lasts roughly 11 seconds before the factory reset routine runs. Make sure to
+leave the device powered on during this countdown; toggling power again during
+this period keeps the counter inside the 10–12 restart window so the
+`lifecycle_factory_reset_and_reboot()` helper eventually executes.

--- a/main/main.c
+++ b/main/main.c
@@ -42,7 +42,8 @@ static const char *TAG = "main";
 
 static const char *RESTART_COUNTER_NAMESPACE = "lcm";
 static const char *RESTART_COUNTER_KEY = "restart_count";
-static const uint32_t RESTART_COUNTER_THRESHOLD = 10U;
+static const uint32_t RESTART_COUNTER_THRESHOLD_MIN = 10U;
+static const uint32_t RESTART_COUNTER_THRESHOLD_MAX = 12U;
 static const uint32_t RESTART_COUNTER_RESET_TIMEOUT_MS = 60000U;
 
 static esp_timer_handle_t restart_counter_timer = NULL;
@@ -246,16 +247,26 @@ static bool handle_power_cycle_sequence(void) {
     ESP_LOGI(TAG, "Consecutive power cycles: %" PRIu32, count);
     restart_counter_store(count);
 
-    if (count >= RESTART_COUNTER_THRESHOLD) {
-        ESP_LOGW(TAG, "Detected %" PRIu32 " consecutive power cycles; starting factory reset countdown",
-                RESTART_COUNTER_THRESHOLD);
-
+    if (count > RESTART_COUNTER_THRESHOLD_MAX) {
+        ESP_LOGW(TAG,
+                "Detected %" PRIu32 " consecutive power cycles; exceeding maximum window %" PRIu32 ", resetting counter",
+                count, RESTART_COUNTER_THRESHOLD_MAX);
         restart_counter_reset();
+        restart_counter_schedule_reset();
+        return false;
+    }
 
-        for (int i = (int)RESTART_COUNTER_THRESHOLD; i >= 0; --i) {
+    if (count >= RESTART_COUNTER_THRESHOLD_MIN) {
+        ESP_LOGW(TAG,
+                "Detected %" PRIu32 " consecutive power cycles within factory reset window (%" PRIu32 "-%" PRIu32 "); starting countdown",
+                count, RESTART_COUNTER_THRESHOLD_MIN, RESTART_COUNTER_THRESHOLD_MAX);
+
+        for (int i = (int)RESTART_COUNTER_THRESHOLD_MIN; i >= 0; --i) {
             ESP_LOGW(TAG, "Factory reset in %d", i);
             vTaskDelay(pdMS_TO_TICKS(1000));
         }
+
+        restart_counter_reset();
 
         lifecycle_factory_reset_and_reboot();
         return true;


### PR DESCRIPTION
## Summary
- allow the factory reset sequence to trigger when 10 to 12 consecutive power cycles are detected
- ensure the restart counter resets only after the countdown and guard against exceeding the window
- update the README to document the wider power-cycle window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94f9d2a248321ab2782d025c6737a