### PR TITLE
Ensure default LED polarity remains active-high by default

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -395,7 +395,15 @@ void app_main(void) {
     if (handle_power_cycle_sequence()) {
         return;
     }
-    if (!load_led_config(&led_enabled, &led_gpio, &led_active_high)) {
+    bool cfg_led_enabled = led_enabled;
+    int cfg_led_gpio = led_gpio;
+    bool cfg_led_active_high = true;
+
+    if (load_led_config(&cfg_led_enabled, &cfg_led_gpio, &cfg_led_active_high)) {
+        led_enabled = cfg_led_enabled;
+        led_gpio = cfg_led_gpio;
+        led_active_high = cfg_led_active_high;
+    } else {
         led_active_high = true;
     }
     gpio_init();


### PR DESCRIPTION
## Summary
- load LED configuration into temporary variables before committing to globals
- preserve the default active-high polarity when no configuration is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee5b06174c8321abbb4d72eff63be6