### PR TITLE
Default LED identification to active low

### DIFF
--- a/main/github_update.c
+++ b/main/github_update.c
@@ -446,7 +446,7 @@ bool load_led_config(bool *enabled, int *gpio, bool *active_high) {
 
     uint8_t en;
     int32_t pin;
-    uint8_t level = 1;
+    uint8_t level = 0;
     err = nvs_get_u8(h, "led_en", &en);
     if (err != ESP_OK) {
         nvs_close(h);
@@ -460,7 +460,7 @@ bool load_led_config(bool *enabled, int *gpio, bool *active_high) {
     err = nvs_get_u8(h, "led_lvl", &level);
     if (err != ESP_OK) {
         if (err == ESP_ERR_NVS_NOT_FOUND) {
-            level = 1;
+            level = 0;
         } else {
             nvs_close(h);
             return false;


### PR DESCRIPTION
## Summary
- default the persisted LED identification level to low so hardware expects an active-low indicator unless overridden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee680807808321b533bb76568a4daa