### PR TITLE
Ensure lifecycle reset init hook anchor is linked

### DIFF
--- a/components/lcm/CMakeLists.txt
+++ b/components/lcm/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(
+    SRCS "src/esp32-lcm.c"
+    INCLUDE_DIRS "include"
+    REQUIRES nvs_flash esp_timer app_update esp_partition
+    PRIV_REQUIRES esp_system
+)
+
+# Forceer link van het anker-symbool zodat de init-hook altijd meekomt
+target_link_options(${COMPONENT_LIB} PUBLIC -u lcm_reset_component_anchor_symbol)

--- a/components/lcm/src/esp32-lcm.c
+++ b/components/lcm/src/esp32-lcm.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+__attribute__((used)) void lcm_reset_component_anchor_symbol(void) {
+    // Anchor symbol to ensure the lifecycle reset component links into the final binary.
+}


### PR DESCRIPTION
## Summary
- add a linker option in the LCM component CMake file so the reset anchor symbol is always pulled in
- provide a minimal anchor symbol implementation to satisfy the forced link reference

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68f4c4881aac832195df2b2af0cb2847