### PR TITLE
Ensure LCM init-hook is always linked (fix reset-sentry not running)

### DIFF
--- a/components/lcm/CMakeLists.txt
+++ b/components/lcm/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(
+    SRCS "src/esp32-lcm.c"
+    INCLUDE_DIRS "include"
+    REQUIRES nvs_flash esp_timer app_update esp_partition
+    PRIV_REQUIRES esp_system
+)
+
+# Forceer link van het anker-symbool zodat de init-hook altijd meekomt
+target_link_options(${COMPONENT_LIB} PUBLIC -u lcm_reset_component_anchor_symbol)


### PR DESCRIPTION
## What
Force-link the LCM component's translation unit so the system init-hook (`ESP_SYSTEM_INIT_FN`) is **always** present at runtime.

Adds:
```cmake
target_link_options(${COMPONENT_LIB} PUBLIC -u lcm_reset_component_anchor_symbol)
```

------
https://chatgpt.com/codex/tasks/task_e_68f4cfaa7e9883218ea58d017cd8f8d5