### PR TITLE
Ensure LCM bootstrap runs before user firmware

### DIFF
--- a/examples/led/main/Kconfig.projbuild
+++ b/examples/led/main/Kconfig.projbuild
@@ -24,4 +24,16 @@ menu "StudioPieters"
               help
                    If you want to change the HomeKit Setup ID, you can do that here (Note: you need to make a new QR-CODE To make it work)
 
+      config LCM_BOOTSTRAP_TASK_STACK_SIZE
+              int "LCM bootstrap task stack size"
+              default 4096
+              help
+                  Stackgrootte voor de taak die tijdens het opstarten de Lifecycle Manager initialiseert.
+
+      config LCM_BOOTSTRAP_TASK_PRIORITY
+              int "LCM bootstrap task priority"
+              default 5
+              help
+                  Taakprioriteit voor de automatische Lifecycle Manager bootstrap taak.
+
 endmenu

--- a/examples/led/main/esp32-lcm.h
+++ b/examples/led/main/esp32-lcm.h
@@ -49,6 +49,8 @@ typedef enum {
     LIFECYCLE_POST_RESET_REASON_UPDATE = 3,
 } lifecycle_post_reset_reason_t;
 
+// Wordt automatisch aangeroepen tijdens het opstarten. Aanroepen na de
+// bootstrap levert geen extra acties meer op.
 void lifecycle_log_post_reset_state(const char *log_tag);
 
 // Initialiseer NVS en voer automatische herstelactie uit wanneer er geen ruimte is of versie verandert.


### PR DESCRIPTION
## Summary
- add Kconfig options for configuring the Lifecycle Manager bootstrap task
- schedule a bootstrap task during system initialisation so the restart counter logic executes before the user app
- document that the post-reset logging helper runs automatically during boot

## Testing
- not run (hardware-dependent project)


------
https://chatgpt.com/codex/tasks/task_e_68f50c84215483219e22a00a8933bdd5