### PR TITLE
Fix ESP-IDF 6 build by renaming json dependency to cjson

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -26,7 +26,7 @@ idf_component_register(
         app_update
         spi_flash
         mbedtls
-        json
+        cjson
         EMBED_TXTFILES
             "content/index.html"
 )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(JSON_COMPONENT json)
+if(DEFINED IDF_VERSION_MAJOR AND IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    set(JSON_COMPONENT cjson)
+endif()
+
 idf_component_register(
     SRCS
         "main.c"
@@ -26,7 +31,7 @@ idf_component_register(
         app_update
         spi_flash
         mbedtls
-        cjson
+        ${JSON_COMPONENT}
         EMBED_TXTFILES
             "content/index.html"
 )


### PR DESCRIPTION
### Motivation
- CMake failed to resolve component `json` when configuring for ESP-IDF 6 (e.g. `idf.py set-target esp32c3`), and the code uses `cJSON_*` APIs so the dependency should be `cjson`.

### Description
- Replace `json` with `cjson` in `main/CMakeLists.txt` inside `idf_component_register(... REQUIRES ...)`.

### Testing
- Ran `rg -n "REQUIRES|PRIV_REQUIRES|json"` to locate the dependency, inspected `main/CMakeLists.txt` with `nl`/`sed`, and committed the change with `git commit`, all of which succeeded; `idf.py set-target` was not rerun in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b68becbc832182965087def45222)