### PR TITLE
Replace legacy `json` dependency with `espressif/cjson`

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -26,7 +26,7 @@ idf_component_register(
         app_update
         spi_flash
         mbedtls
-        json
+        cjson
         EMBED_TXTFILES
             "content/index.html"
 )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,3 +1,4 @@
 dependencies:
   idf:
     version: ">=5.0"
+  espressif/cjson: "*"


### PR DESCRIPTION
### Motivation
- Replace the ambiguous `json` component with the official cJSON package so the correct JSON library is pulled in during the ESP-IDF build.

### Description
- Change `main/CMakeLists.txt` to require `cjson` instead of `json` and add `espressif/cjson` to `main/idf_component.yml` dependencies.

### Testing
- Ran project configuration and `idf.py build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b68becbc832182965087def45222)