### PR TITLE
Fix build: IDF GPIO dependency and mbedTLS SHA256 API compatibility

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(JSON_COMPONENT json)
+set(DRIVER_COMPONENT driver)
 if(DEFINED IDF_VERSION_MAJOR AND IDF_VERSION_MAJOR GREATER_EQUAL 6)
     set(JSON_COMPONENT cjson)
+    set(DRIVER_COMPONENT esp_driver_gpio)
 endif()
 
 idf_component_register(
@@ -21,7 +23,7 @@ idf_component_register(
         freertos
         esp_wifi
         nvs_flash
-        driver
+        ${DRIVER_COMPONENT}
         esp_event
         esp_netif
         esp_timer

--- a/main/github_update.c
+++ b/main/github_update.c
@@ -10,7 +10,7 @@
 #include "esp_app_desc.h"
 #include "esp_crt_bundle.h"
 #include "soc/soc_caps.h"
-#include "mbedtls/sha256.h"
+#include "mbedtls/md.h"
 #include "mbedtls/pk.h"
 #include "esp_image_format.h"
 #include "cJSON.h"
@@ -731,13 +731,14 @@ static esp_err_t download_signature(const char *url, uint8_t *buf, size_t buf_le
 
 static esp_err_t partition_sha256(const esp_partition_t *part, uint32_t len, uint8_t *out)
 {
-    mbedtls_sha256_context ctx;
+    mbedtls_md_context_t ctx;
+    const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     uint8_t *buf = malloc(4096);
     if (!buf) return ESP_ERR_NO_MEM;
-    mbedtls_sha256_init(&ctx);
-    if (mbedtls_sha256_starts(&ctx, 0) != 0) {
+    mbedtls_md_init(&ctx);
+    if (md_info == NULL || mbedtls_md_setup(&ctx, md_info, 0) != 0 || mbedtls_md_starts(&ctx) != 0) {
         free(buf);
-        mbedtls_sha256_free(&ctx);
+        mbedtls_md_free(&ctx);
         return ESP_FAIL;
     }
 
@@ -748,23 +749,23 @@ static esp_err_t partition_sha256(const esp_partition_t *part, uint32_t len, uin
         esp_err_t r = esp_partition_read(part, offset, buf, to_read);
         if (r != ESP_OK) {
             free(buf);
-            mbedtls_sha256_free(&ctx);
+            mbedtls_md_free(&ctx);
             return r;
         }
-        if (mbedtls_sha256_update(&ctx, buf, to_read) != 0) {
+        if (mbedtls_md_update(&ctx, buf, to_read) != 0) {
             free(buf);
-            mbedtls_sha256_free(&ctx);
+            mbedtls_md_free(&ctx);
             return ESP_FAIL;
         }
         offset += to_read;
     }
 
-    if (mbedtls_sha256_finish(&ctx, out) != 0) {
+    if (mbedtls_md_finish(&ctx, out) != 0) {
         free(buf);
-        mbedtls_sha256_free(&ctx);
+        mbedtls_md_free(&ctx);
         return ESP_FAIL;
     }
-    mbedtls_sha256_free(&ctx);
+    mbedtls_md_free(&ctx);
     free(buf);
     return ESP_OK;
 }


### PR DESCRIPTION
### Motivation
- The project failed to compile because `main` used `driver/gpio.h` but did not declare the correct IDF component when ESP-IDF split GPIO into `esp_driver_gpio` for IDF 6+.
- Direct use of `mbedtls/sha256.h` caused API/compatibility errors with the mbedTLS distribution in some IDF versions.

### Description
- Add a version-aware `DRIVER_COMPONENT` in `main/CMakeLists.txt` that defaults to `driver` and switches to `esp_driver_gpio` when `IDF_VERSION_MAJOR >= 6`, then use `${DRIVER_COMPONENT}` in the `REQUIRES` list.
- Replace `#include "mbedtls/sha256.h"` with `#include "mbedtls/md.h"` in `main/github_update.c` and reimplement `partition_sha256` to use the generic mbedTLS MD API (`mbedtls_md_context_t`, `mbedtls_md_info_from_type`, `mbedtls_md_setup`, `mbedtls_md_starts`, `mbedtls_md_update`, `mbedtls_md_finish`, `mbedtls_md_free`).
- Update error handling and resource cleanup in `partition_sha256` to free the buffer and call `mbedtls_md_free` on all failure paths.

### Testing
- Ran `idf.py build` in the project root, which completed successfully and produced the firmware image (`build/esp32-lifecycle-manager.bin`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c1d9e5888321a39d6d25e7da3842)