### PR TITLE
fix(led): remove unavailable espressif/json dependency from LED example

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -5,5 +5,3 @@ dependencies:
     version: ">=1.3.7"
   achimpieters/esp32-button:
     version: ">=1.2.3"
-  espressif/json:
-    version: "*"


### PR DESCRIPTION
### Motivation
- Removing the `espressif/json` registry dependency prevents ESP-IDF v6's dependency solver from failing during CMake configure because the package no longer resolves and the example already provides a local compatibility shim.

### Description
- Deleted the `espressif/json` dependency entry from `examples/led/main/idf_component.yml` so dependency resolution no longer requires the unavailable registry component.

### Testing
- Attempted the Docker-based build (`docker run ... espressif/idf:v6.0 ... idf.py set-target esp32c3 build`) but `docker` is not available in this environment so the build could not be executed; the manifest change was validated by inspecting the file with `nl -ba examples/led/main/idf_component.yml` and committing the change with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dcf99db883219a5198c185573e22)