### PR TITLE
Allow ESP-IDF 6.x in component manifests

### DIFF
--- a/examples/led/main/idf_component.yml
+++ b/examples/led/main/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: ">=5.0,<6.0"
+    version: ">=5.0,<7.0"
   achimpieters/esp32-homekit:
     version: ">=3.0.0"
   achimpieters/esp32-button:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,7 +8,7 @@ repository: "https://github.com/AchimPieters/esp32-lifecycle-manager"
 issues: "https://github.com/AchimPieters/esp32-lifecycle-manager/issues"
 license: "MIT"
 dependencies:
-  idf: ">=5.0,<6.0"
+  idf: ">=5.0,<7.0"
   espressif/cjson: "*"
 targets:
   - "esp32"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf:
-    version: ">=5.0,<6.0"
+    version: ">=5.0,<7.0"
   espressif/cjson: "*"


### PR DESCRIPTION
### Motivation
- Building inside an ESP-IDF 6.x environment failed dependency resolution because the manifests restricted IDF to `>=5.0,<6.0`, so the project must accept 6.x releases.

### Description
- Relaxed the `idf` dependency upper bound from `<6.0` to `<7.0` in `idf_component.yml`.
- Applied the same `>=5.0,<7.0` change to `main/idf_component.yml`.
- Applied the same `>=5.0,<7.0` change to `examples/led/main/idf_component.yml`.

### Testing
- Ran `idf.py --version` which completed successfully and returned the IDF version.
- Ran `idf.py reconfigure` which completed successfully and generated build files and an updated `dependencies.lock`.
- Verified manifest updates with `rg` searching for the new `>=5.0,<7.0` range which succeeded.
- Ran `git status --short` to confirm repository state which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c938891f708321917787ffdee4c3fe)