### PR TITLE
Relax default runtime NVS encryption requirement

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -22,7 +22,7 @@ config LCM_RESTART_COUNTER_TIMEOUT_MS
 
 config LCM_REQUIRE_NVS_ENCRYPTION
     bool "Require NVS encryption at runtime"
-    default y
+    default n
     help
         If enabled, startup aborts unless ESP-IDF NVS encryption is enabled
         in sdkconfig (`CONFIG_NVS_ENCRYPTION`).

--- a/main/main.c
+++ b/main/main.c
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef CONFIG_LCM_REQUIRE_NVS_ENCRYPTION
-#define CONFIG_LCM_REQUIRE_NVS_ENCRYPTION 1
+#define CONFIG_LCM_REQUIRE_NVS_ENCRYPTION 0
 #endif
 
 static const char *TAG = "main";


### PR DESCRIPTION
### Motivation
- Prevent development/devboard flashes from aborting startup when `CONFIG_NVS_ENCRYPTION` is not enabled by making the runtime NVS encryption requirement opt-in by default.

### Description
- Change `LCM_REQUIRE_NVS_ENCRYPTION` Kconfig default from `y` to `n` in `main/Kconfig.projbuild`.
- Update the compile-time fallback in `main/main.c` to set `CONFIG_LCM_REQUIRE_NVS_ENCRYPTION` to `0` so builds without a generated config do not fail startup by default.

### Testing
- Ran `pytest -q`; all tests passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95141ba5483218fbf52f45acde709)