### PR TITLE
Add end-user guide and documentation map; warn about example signing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ application firmware, keeps it up to date, and offers recovery tools when
 something goes wrong. Even if you are new to ESP-IDF, LCM guides you from an
 unconfigured module to a fully managed device in a few straightforward steps.
 
+
+## Documentation map
+
+To make this repository easier to navigate:
+
+- **End users / installers / support**: see [`enduser.md`](./enduser.md) for onboarding, OTA operation, reset procedures, and troubleshooting.
+- **Developers / integrators**: continue with this `README.md` for build, signing, and flashing workflows.
+- **Security and operations detail**: see [`docs/security`](./docs/security) and [`docs/operations`](./docs/operations).
+
+### Important security warning
+
+This repository contains example key files (`ota_signing_private.pem` and `ota_signing_public.pem`) for demonstration purposes. Do **not** use these keys in production. Always generate and protect your own signing keys before shipping devices.
+
 ## How LCM operates
 
 At every boot LCM starts before your application. It evaluates whether the

--- a/enduser.md
+++ b/enduser.md
@@ -1,0 +1,100 @@
+# ESP32 Lifecycle Manager (LCM) – End User Guide
+
+This guide is written for installers, support staff, and operators. It explains
+how to provision a device, perform updates, recover from failure states, and
+apply safe key-handling practices.
+
+## 1) What LCM does for you
+
+LCM is the management firmware that boots before your application firmware and
+handles lifecycle operations:
+
+- onboarding devices through AP/captive portal,
+- storing Wi-Fi credentials,
+- fetching signed firmware from your configured repository,
+- validating signatures before booting updates,
+- and offering recovery/reset flows.
+
+## 2) What you need before onboarding
+
+Prepare the following:
+
+- device flashed with ESP32 Lifecycle Manager,
+- phone/laptop that can connect to Wi-Fi,
+- Wi-Fi SSID + password,
+- GitHub repo/release source that contains:
+  - `main.bin`
+  - `main.bin.sig`.
+
+## 3) First-time onboarding
+
+1. Power on the device.
+2. Join the LCM hotspot (AP mode).
+3. Let captive portal open automatically (or browse to `http://192.168.4.1`).
+4. In the portal:
+   - choose visible SSID or enter hidden SSID,
+   - enter Wi-Fi password,
+   - configure repository URL used for firmware fetch,
+   - optionally blink LED to identify the target board.
+5. Save/apply settings.
+6. Wait for LCM to download firmware and signature.
+7. Device validates signature and then boots application firmware.
+
+## 4) OTA update behavior (operator view)
+
+- LCM only accepts update binaries when verification succeeds.
+- If verification fails (signature mismatch, bad metadata, corrupted transfer),
+  update is rejected and device should remain on a known good image.
+- Trigger update using your integration's OTA trigger flow.
+
+## 5) Reset and recovery
+
+### Software factory reset
+Use your exposed API/control path to erase stored configuration and reboot.
+
+### Hardware factory reset pattern
+Power-cycle or reset the board **10 consecutive times** to trigger the
+hardware reset flow and return to onboarding mode.
+
+## 6) Quick troubleshooting
+
+### Captive portal does not appear
+
+- Confirm you are connected to the LCM AP.
+- Open `http://192.168.4.1` manually.
+- Disable mobile data temporarily to force captive portal behavior on phones.
+
+### Firmware fails to install
+
+- Confirm both `main.bin` and `main.bin.sig` are published.
+- Ensure the signature matches the exact binary version.
+- Verify repository URL and release asset names.
+
+### Device keeps returning to setup mode
+
+- Re-enter Wi-Fi credentials and ensure signal is stable.
+- Re-run onboarding and re-check repository settings.
+- Use factory reset and provision again.
+
+## 7) Security note about keys in this repository
+
+This repository currently includes sample key material:
+
+- `ota_signing_private.pem`
+- `ota_signing_public.pem`
+
+These must be treated as **example-only** and **not trusted for production**.
+
+For real deployments:
+
+1. Generate your own key pair.
+2. Keep private keys out of Git and CI logs.
+3. Re-sign all release binaries using your private key.
+4. Distribute only the matching public key to devices.
+5. Rotate keys immediately if exposure is suspected.
+
+## 8) Where to find technical docs
+
+- Engineer/developer reference: `README.md`
+- Security docs: `docs/security/`
+- Ops/recovery docs: `docs/operations/`


### PR DESCRIPTION
### Motivation

- Improve discoverability by introducing a documentation map that separates end-user, developer, and security/ops content.
- Provide clear onboarding, OTA, recovery, and key-handling instructions for installers and operators.
- Surface an explicit security warning about example signing keys included in the repository.

### Description

- Added a Documentation map and an "Important security warning" to `README.md` to guide readers to the appropriate docs and warn about example key material.  
- Added a new `enduser.md` file containing an end-user guide with sections on onboarding, OTA update behavior, reset/recovery, troubleshooting, and key management.  
- Clarified required repository assets (`main.bin` and `main.bin.sig`) and described the captive portal/AP onboarding flow.  
- Emphasized that `ota_signing_private.pem` and `ota_signing_public.pem` are example keys and must not be used in production.

### Testing

- This is a documentation-only change and no automated tests were executed as part of the update.  
- No source code or behavior was modified by these changes, so no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12069a3408321b1d8beb73f8a91c2)