### PR TITLE
Introduce publisher modes, target-aware signing, key tooling, and CI/docs updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           openssl ecparam -name prime256v1 -genkey -noout -out keys/ota_signing_private.pem
           dd if=/dev/zero of=build/main.bin bs=1024 count=1
       - name: Generate signed metadata
-        run: ./generate_sig.sh build/main.bin keys/ota_signing_private.pem
+        run: ./scripts/sign_firmware.sh build/main.bin keys/ota_signing_private.pem esp32
       - name: Verify signature file exists
         run: test -f build/main.bin.sig
 
@@ -40,7 +40,7 @@ jobs:
       matrix:
         # Keep CI on targets that are currently validated to pass reliably.
         # Re-enable additional targets after dedicated per-target fixes land.
-        target: [esp32, esp32c2]
+        target: [esp32, esp32c2, esp32c3]
     steps:
       - uses: actions/checkout@v4
       - name: ESP-IDF build (${{ matrix.target }})

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,11 @@ dkms.conf
 
 # debug information files
 *.dwo
+
+# LCM signing secrets and local signing output
+keys/private/
+keys/custom_public_key.h
+keys/private/*.pem
+keys/private/*.key
+*.sig.tmp
+signing-output/

--- a/README.md
+++ b/README.md
@@ -1,211 +1,84 @@
 # ESP32 Lifecycle Manager (LCM)
 
-ESP32 Lifecycle Manager (LCM) is a lightweight helper firmware that shepherds an
-ESP32-based device through its entire lifecycle. You can think of it as the
-"operations center" that boots first, prepares network access, installs your
-application firmware, keeps it up to date, and offers recovery tools when
-something goes wrong. Even if you are new to ESP-IDF, LCM guides you from an
-unconfigured module to a fully managed device in a few straightforward steps.
+LCM is a generic **signed update loader** for ESP32-family chips. End users flash an LCM image once, configure an update source, and LCM securely downloads `main.bin` + `main.bin.sig`, verifies them, and installs updates.
 
+## Quick start for end users (official mode)
 
-## Documentation map
+1. Download and flash the binary matching your chip (examples):
+   - `lcm-esp32.bin`
+   - `lcm-esp32c2.bin`
+   - `lcm-esp32c3.bin`
+2. Open the captive portal and configure Wi-Fi + update source.
+3. Set update source as either:
+   - GitHub repository slug: `owner/repo` (release assets `main.bin`, `main.bin.sig`), or
+   - Direct HTTP/HTTPS base URL containing `main.bin` and `main.bin.sig`.
+4. Trigger update.
 
-To make this repository easier to navigate:
+In official mode, no key generation and no rebuild is needed.
 
-- **End users / installers / support**: see [`enduser.md`](./enduser.md) for onboarding, OTA operation, reset procedures, and troubleshooting.
-- **Developers / integrators**: continue with this `README.md` for build, signing, and flashing workflows.
-- **Security and operations detail**: see [`docs/security`](./docs/security) and [`docs/operations`](./docs/operations).
+## Publishing signed firmware
 
-### Important security warning
-
-This repository contains example key files (`ota_signing_private.pem` and `ota_signing_public.pem`) for demonstration purposes. Do **not** use these keys in production. Always generate and protect your own signing keys before shipping devices.
-
-## How LCM operates
-
-At every boot LCM starts before your application. It evaluates whether the
-system can continue normal operation or whether maintenance is required. The
-firmware stores Wi-Fi credentials, checks for new releases, validates firmware
-signatures, and triggers recovery flows when necessary. This means you do not
-need to build these management utilities yourself—LCM bundles the essentials for
-remote lifecycle control of ESP32 devices.
-
-## Core capabilities
-
-### Access Point (AP) mode
-
-LCM can launch a temporary access point so the device remains reachable even
-before any Wi-Fi network has been configured. Connect to this hotspot to perform
-initial setup.
-
-### Captive portal (CNA)
-
-When you join the LCM access point a captive portal automatically opens. From
-this portal you can:
-
-- **Select a visible Wi-Fi network** and provide its password.
-- **Add a hidden Wi-Fi network manually** by entering the SSID and password.
-- **Configure the GitHub repository URL** where LCM should look for new
-  firmware releases (`main.bin` and `main.bin.sig`).
-- **Blink the status LED for identification** so you can confirm you are working
-  with the correct device during installation or servicing.
-
-<img src="https://github.com/AchimPieters/esp32-lifecycle-manager/blob/main/main_screen.png" width="400">
-
-### Downloading and installing `main.bin`
-
-After provisioning, LCM downloads `main.bin` and the accompanying
-`main.bin.sig`. It validates the SHA-384 signature as well as the reported file
-size and only activates the firmware when the verification succeeds.
-
-### Software update (`ota_trigger`)
-
-You can initiate an over-the-air update through an OTA trigger (for example via
-an HTTP request) whenever a new release becomes available.
-
-### Hardware-assisted update
-
-LCM can listen to hardware controls such as a physical button to start or
-confirm the update flow. This is useful for devices that must update without a
-connected computer.
-
-### Reset and recovery options
-
-- **Software factory reset** – Use the LCM API to erase the stored configuration
-  and reboot the device.
-- **Hardware factory reset** – Quickly power-cycle or reset the device 10 times
-  in succession. Once LCM detects the pattern it starts an ~11 second countdown
-  and performs the factory reset automatically.
-
-### Automatic firmware version stamping
-
-During installation or update LCM writes the value of
-`LIFECYCLE_DEFAULT_FW_VERSION` so you can verify remotely which firmware version
-is running.
-
-## Typical installation flow
-
-1. **First boot** – LCM starts in AP mode and exposes the captive portal.
-2. **Network provisioning** – The installer links the device to a Wi-Fi network
-   and stores the GitHub repository that hosts signed firmware releases.
-3. **Firmware acquisition** – LCM downloads `main.bin` and `main.bin.sig`,
-   validates both files, and activates the firmware upon success.
-4. **Normal operation** – Your application firmware now runs while LCM remains on
-   standby to handle OTA updates and recovery tasks.
-
-## Building LCM with ESP-IDF
-
-1. Install ESP-IDF by following the official Espressif documentation.
-2. Select the correct target for your board:
-
-   ```bash
-   idf.py set-target esp32        # or esp32s2, esp32s3, esp32c3, ...
-   ```
-
-3. Build the lifecycle manager firmware:
-
-   ```bash
-   idf.py build
-   ```
-
-   The resulting `main.bin` will be placed inside the `build/` directory.
-
-### ESP-IDF compatibility status
-
-- **Primary validated line:** ESP-IDF `v5.4.2` (full build + tests in CI).
-- **ESP-IDF `v6.0` status:** pending full CI validation; use staging before production rollout.
-- **Officially targeted by this repository:** `esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`.
-- **Not currently targeted:** `esp32c5`, `esp32c6`, `esp32c61`.
-
-## Signing `main.bin`
-
-Every firmware release must be accompanied by a signature file generated by
-`generate_sig.sh` (ECDSA P-256 metadata/signature blob expected by the OTA
-verifier in this project):
+Use local scripts:
 
 ```bash
-./generate_sig.sh build/main.bin /path/to/ota_signing_private.pem
+./scripts/generate_keys.sh keys/private publisher
+./scripts/sign_firmware.sh build/main.bin keys/private/publisher_private.pem esp32c3
 ```
 
-Upload both files to a GitHub release (for example version `0.0.1`). Follow
-[Semantic Versioning](https://semver.org/) when deciding on the version number:
+Outputs:
+- private key (local only)
+- public key (shareable)
+- `main.bin.sig`
 
-- Increase **MAJOR** for incompatible API changes.
-- Increase **MINOR** when you add backward-compatible functionality.
-- Increase **PATCH** for backward-compatible bug fixes.
+## Building LCM with a custom key
 
-## Flash instructions by chipset
-
-Use `esptool.py` (installable via `pip install esptool`) and replace the
-filenames with the artifacts produced by your build.
-
-### ESP32
+1. Copy `keys/custom_public_key.example.h` to `keys/custom_public_key.h`.
+2. Paste your public key PEM into `LCM_CUSTOM_PUBLIC_KEY_PEM`.
+3. Enable custom mode:
 
 ```bash
-python -m esptool --chip esp32 -b 460800 --before default_reset --after hard_reset \
-  write_flash --flash_mode dio --flash_size 4MB --flash_freq 40m \
-  0x1000 bootloader.bin \
-  0x8000 partition-table.bin \
-  0xe000 ota_data_initial.bin \
-  0x20000 esp32-lifecycle-manager.bin
+idf.py menuconfig
+# StudioPieters -> Trusted publisher mode -> Custom publisher mode
+# (sets CONFIG_LCM_CUSTOM_KEY=y)
 ```
 
-### ESP32-S2
+4. Build per target:
 
 ```bash
-python -m esptool --chip esp32s2 -b 460800 --before default_reset --after hard_reset \
-  write_flash --flash_mode dio --flash_size 4MB --flash_freq 80m \
-  0x1000 bootloader.bin \
-  0x8000 partition-table.bin \
-  0xe000 ota_data_initial.bin \
-  0x20000 esp32-lifecycle-manager.bin
+idf.py set-target esp32 && idf.py build
+idf.py set-target esp32c2 && idf.py build
+idf.py set-target esp32c3 && idf.py build
 ```
 
-### ESP32-S3
+## Security model
 
-```bash
-python -m esptool --chip esp32s3 -b 460800 --before default_reset --after hard_reset \
-  write_flash --flash_mode dio --flash_size 4MB --flash_freq 80m \
-  0x1000 bootloader.bin \
-  0x8000 partition-table.bin \
-  0xe000 ota_data_initial.bin \
-  0x20000 esp32-lifecycle-manager.bin
-```
+- **Official builds** trust the built-in official public key (`keys/official_public_key.h`).
+- **Custom builds** trust your custom public key (`keys/custom_public_key.h`).
+- In Official mode, end users explicitly trust the official signer trust-chain shipped by this project.
+- If signature verification fails, update is rejected.
+- If firmware target in signature does not match device target, update is rejected.
+- Private signing keys must never be committed.
 
-### ESP32-C2
+## Architecture notes
 
-```bash
-python -m esptool --chip esp32c2 -b 460800 --before default_reset --after hard_reset \
-  write_flash --flash_mode dio --flash_size 4MB --flash_freq 60m \
-  0x1000 bootloader.bin \
-  0x8000 partition-table.bin \
-  0xe000 ota_data_initial.bin \
-  0x20000 esp32-lifecycle-manager.bin
-```
+LCM separates:
+- network/release fetch,
+- signature verification + trusted key provider,
+- OTA install + reboot.
 
-### ESP32-C3
+Manifest support (`manifest.json`) is intentionally prepared as a next step; v1 keeps minimal package support with `main.bin` and `main.bin.sig`.
 
-```bash
-python -m esptool --chip esp32c3 -b 460800 --before default_reset --after hard_reset \
-  write_flash --flash_mode dio --flash_size 4MB --flash_freq 80m \
-  0x1000 bootloader.bin \
-  0x8000 partition-table.bin \
-  0xe000 ota_data_initial.bin \
-  0x20000 esp32-lifecycle-manager.bin
-```
+## Key rotation (operational guidance)
 
-### ESP32-C5 / ESP32-C6 / ESP32-C61
+- Official mode should rotate signing keys periodically.
+- Rotation should be done with overlap windows (old + new trusted public keys) in a later release.
+- Custom publishers should keep a migration plan for replacing their own trust anchor.
 
-These targets are currently **not part of the official targeted set** in this
-repository. Bring-up can be done experimentally, but production support is only
-claimed for the targets listed above.
+## Multi-target release artifacts
 
-## Reset and recovery recap
+CI builds target-aware artifacts for release distribution. Naming convention:
+- `lcm-esp32.bin`
+- `lcm-esp32c2.bin`
+- `lcm-esp32c3.bin`
 
-- **Software factory reset** – Triggered through the LCM API to wipe stored
-  configuration and reboot.
-- **Hardware factory reset** – Power-cycle or reset the device 10 consecutive
-  times. LCM detects the pattern, waits roughly 11 seconds, and then executes the
-  factory reset.
-
-Armed with these steps you can quickly provision an ESP32 device, deploy your
-own firmware, and keep it managed remotely through LCM.
+Extendable to additional supported ESP32 variants.

--- a/enduser.md
+++ b/enduser.md
@@ -1,100 +1,102 @@
 # ESP32 Lifecycle Manager (LCM) – End User Guide
 
-This guide is written for installers, support staff, and operators. It explains
-how to provision a device, perform updates, recover from failure states, and
-apply safe key-handling practices.
+This guide explains how an end user or installer uses LCM after flashing it to an ESP32-family board.
 
-## 1) What LCM does for you
+## 1) Official mode vs custom mode
 
-LCM is the management firmware that boots before your application firmware and
-handles lifecycle operations:
+### Official mode (default)
+For most users.
 
-- onboarding devices through AP/captive portal,
-- storing Wi-Fi credentials,
-- fetching signed firmware from your configured repository,
-- validating signatures before booting updates,
-- and offering recovery/reset flows.
+- The flashed LCM build already contains the official public verification key.
+- You do **not** need to generate keys.
+- You do **not** need to rebuild LCM.
+- LCM accepts firmware only when it is signed by the matching official private key.
+
+### Custom publisher mode (advanced)
+For advanced users/integrators.
+
+- You build LCM yourself with your own public key.
+- You sign your own firmware with your own private key.
+- You control your own trust chain.
 
 ## 2) What you need before onboarding
 
-Prepare the following:
+Prepare:
 
-- device flashed with ESP32 Lifecycle Manager,
-- phone/laptop that can connect to Wi-Fi,
+- an ESP32 board flashed with the correct LCM image for that chip type,
+- phone/laptop with Wi-Fi,
 - Wi-Fi SSID + password,
-- GitHub repo/release source that contains:
+- update source that provides at least:
   - `main.bin`
-  - `main.bin.sig`.
+  - `main.bin.sig`
+
+Supported source formats:
+
+1. GitHub repository slug: `owner/repo` (release assets), or
+2. Direct HTTP/HTTPS base URL that hosts `main.bin` and `main.bin.sig`.
 
 ## 3) First-time onboarding
 
 1. Power on the device.
-2. Join the LCM hotspot (AP mode).
-3. Let captive portal open automatically (or browse to `http://192.168.4.1`).
-4. In the portal:
-   - choose visible SSID or enter hidden SSID,
-   - enter Wi-Fi password,
-   - configure repository URL used for firmware fetch,
-   - optionally blink LED to identify the target board.
-5. Save/apply settings.
-6. Wait for LCM to download firmware and signature.
-7. Device validates signature and then boots application firmware.
+2. Connect to the LCM AP hotspot.
+3. Open captive portal (or browse to `http://192.168.4.1`).
+4. Configure:
+   - Wi-Fi credentials,
+   - update source,
+   - optional LED blink for board identification.
+5. Save settings.
+6. LCM downloads update artifacts.
+7. LCM verifies signature and target compatibility.
+8. If valid, firmware is activated and device reboots.
 
-## 4) OTA update behavior (operator view)
+## 4) Update validation behavior
 
-- LCM only accepts update binaries when verification succeeds.
-- If verification fails (signature mismatch, bad metadata, corrupted transfer),
-  update is rejected and device should remain on a known good image.
-- Trigger update using your integration's OTA trigger flow.
+LCM rejects updates when one of these checks fails:
 
-## 5) Reset and recovery
+- package incomplete (`main.bin` / `main.bin.sig` missing),
+- signature invalid,
+- firmware not signed by trusted publisher,
+- firmware target does not match device,
+- download/HTTP failure.
 
-### Software factory reset
-Use your exposed API/control path to erase stored configuration and reboot.
+When validation fails, LCM should stay on a known good image.
 
-### Hardware factory reset pattern
-Power-cycle or reset the board **10 consecutive times** to trigger the
-hardware reset flow and return to onboarding mode.
+## 5) Quick troubleshooting
 
-## 6) Quick troubleshooting
-
-### Captive portal does not appear
+### Captive portal does not open
 
 - Confirm you are connected to the LCM AP.
 - Open `http://192.168.4.1` manually.
-- Disable mobile data temporarily to force captive portal behavior on phones.
+- Disable mobile data temporarily (phone CNA behavior).
 
-### Firmware fails to install
+### Update fails
 
-- Confirm both `main.bin` and `main.bin.sig` are published.
-- Ensure the signature matches the exact binary version.
-- Verify repository URL and release asset names.
+- Verify update source path/repo is correct.
+- Confirm both `main.bin` and `main.bin.sig` are available.
+- Confirm signature was generated for the same `main.bin` and correct chip target.
 
 ### Device keeps returning to setup mode
 
-- Re-enter Wi-Fi credentials and ensure signal is stable.
-- Re-run onboarding and re-check repository settings.
-- Use factory reset and provision again.
+- Re-enter Wi-Fi credentials and verify signal quality.
+- Re-check update source configuration.
+- Run factory reset and onboard again.
 
-## 7) Security note about keys in this repository
+## 6) Reset and recovery
 
-This repository currently includes sample key material:
+### Software factory reset
+Use your control/API path to clear stored configuration and reboot.
 
-- `ota_signing_private.pem`
-- `ota_signing_public.pem`
+### Hardware reset pattern
+Power-cycle or reset the board **10 consecutive times** to trigger hardware factory reset and return to onboarding mode.
 
-These must be treated as **example-only** and **not trusted for production**.
+## 7) Security notes
 
-For real deployments:
+- Never publish private signing keys.
+- In official mode, end users trust the official signer chain shipped in LCM.
+- In custom mode, users trust the custom key compiled into their own build.
 
-1. Generate your own key pair.
-2. Keep private keys out of Git and CI logs.
-3. Re-sign all release binaries using your private key.
-4. Distribute only the matching public key to devices.
-5. Rotate keys immediately if exposure is suspected.
+## 8) More documentation
 
-## 8) Where to find technical docs
-
-- Engineer/developer reference: `README.md`
+- Main project docs: `README.md`
 - Security docs: `docs/security/`
-- Ops/recovery docs: `docs/operations/`
+- Operations/recovery docs: `docs/operations/`

--- a/generate_sig.sh
+++ b/generate_sig.sh
@@ -1,53 +1,8 @@
-#!/bin/sh
-# Generate a cryptographic main.bin.sig using ECDSA P-256 + SHA-256.
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
 TARGET_PATH="${1:-build/main.bin}"
-PRIVATE_KEY_PATH="${2:-keys/ota_signing_private.pem}"
+PRIVATE_KEY_PATH="${2:-keys/private/publisher_private.pem}"
+TARGET_NAME="${3:-esp32}"
 
-if [ -d "$TARGET_PATH" ]; then
-  TARGET_PATH="${TARGET_PATH%/}/main.bin"
-fi
-
-if [ ! -f "$TARGET_PATH" ]; then
-  echo "Firmware image not found: $TARGET_PATH" >&2
-  exit 1
-fi
-
-if [ ! -f "$PRIVATE_KEY_PATH" ]; then
-  echo "Private key not found: $PRIVATE_KEY_PATH" >&2
-  echo "Generate one with: openssl ecparam -name prime256v1 -genkey -noout -out $PRIVATE_KEY_PATH" >&2
-  exit 1
-fi
-
-SIGNATURE_PATH="$TARGET_PATH.sig"
-TMP_HASH="$(mktemp)"
-TMP_DER="$(mktemp)"
-trap 'rm -f "$TMP_HASH" "$TMP_DER"' EXIT
-
-openssl dgst -sha256 -binary -out "$TMP_HASH" "$TARGET_PATH"
-openssl dgst -sha256 -sign "$PRIVATE_KEY_PATH" -out "$TMP_DER" "$TARGET_PATH"
-
-python3 - "$TARGET_PATH" "$TMP_HASH" "$TMP_DER" "$SIGNATURE_PATH" <<'PY'
-import os
-import struct
-import sys
-
-firmware_path, hash_path, sig_der_path, output_path = sys.argv[1:5]
-firmware_len = os.path.getsize(firmware_path)
-firmware_hash = open(hash_path, 'rb').read()
-signature_der = open(sig_der_path, 'rb').read()
-
-MAGIC = 0x4C434D53  # LCMS
-VERSION = 1
-ALGORITHM = 1  # ECDSA P-256 SHA-256
-RESERVED = 0
-
-header = struct.pack('<IBBHI32sH', MAGIC, VERSION, ALGORITHM, RESERVED,
-                     firmware_len, firmware_hash, len(signature_der))
-with open(output_path, 'wb') as f:
-    f.write(header)
-    f.write(signature_der)
-
-print(f"Wrote {output_path} ({len(header) + len(signature_der)} bytes)")
-PY
+"$(dirname "$0")/scripts/sign_firmware.sh" "$TARGET_PATH" "$PRIVATE_KEY_PATH" "$TARGET_NAME"

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,12 @@
+# LCM key files
+
+- `official_public_key.h`: default trust anchor used by official mode builds.
+- `custom_public_key.example.h`: template for advanced users.
+
+## Custom mode
+
+1. Copy `custom_public_key.example.h` to `custom_public_key.h`.
+2. Replace the PEM body with your own ECDSA P-256 public key.
+3. Enable `CONFIG_LCM_PUBLISHER_MODE_CUSTOM=y` in menuconfig/sdkconfig.
+
+> Private keys are never required by the firmware build and must never be committed.

--- a/keys/custom_public_key.example.h
+++ b/keys/custom_public_key.example.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Copy this file to `keys/custom_public_key.h` for custom publisher mode.
+// Keep only a PUBLIC key in this header; never store private keys in git.
+#define LCM_CUSTOM_PUBLIC_KEY_PEM \
+"-----BEGIN PUBLIC KEY-----\n" \
+"REPLACE_WITH_YOUR_BASE64_KEY_MATERIAL\n" \
+"-----END PUBLIC KEY-----\n"

--- a/keys/official_public_key.h
+++ b/keys/official_public_key.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Official StudioPieters LCM trust anchor (public key only).
+#define LCM_OFFICIAL_PUBLIC_KEY_PEM \
+"-----BEGIN PUBLIC KEY-----\n" \
+"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECoIqacNbCn1oWreXsb2QTz6c+hOj\n" \
+"ezXGuO01nfuVl/+sH2iB8bvkGnwW+f14lzqsQQ6H8DMxIRJCNjGMNqrYjg==\n" \
+"-----END PUBLIC KEY-----\n"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -15,10 +15,12 @@ idf_component_register(
         "lifecycle_reset.c"
         "lifecycle_restart_counter.c"
         "nvs_store.c"
+        "lcm_key_provider.c"
     INCLUDE_DIRS
         "."
         "include"
         "content"
+        "${CMAKE_CURRENT_LIST_DIR}/../keys"
     REQUIRES
         freertos
         esp_wifi

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,5 +1,28 @@
 menu "StudioPieters"
 
+choice LCM_PUBLISHER_MODE
+    prompt "Trusted publisher mode"
+    default LCM_PUBLISHER_MODE_OFFICIAL
+    help
+        Official mode is intended for end users and uses the built-in official
+        public verification key. Custom mode is intended for advanced users.
+
+config LCM_PUBLISHER_MODE_OFFICIAL
+    bool "Official publisher mode (default)"
+
+config LCM_PUBLISHER_MODE_CUSTOM
+    bool "Custom publisher mode"
+
+endchoice
+
+config LCM_OFFICIAL_KEY
+    bool
+    default y if LCM_PUBLISHER_MODE_OFFICIAL
+
+config LCM_CUSTOM_KEY
+    bool
+    default y if LCM_PUBLISHER_MODE_CUSTOM
+
 config ESP_LED_GPIO
     int "Set the GPIO for the LED"
     default 2

--- a/main/github_update.c
+++ b/main/github_update.c
@@ -42,6 +42,7 @@
 #include "led_indicator.h"
 #include "nvs_keys.h"
 #include "nvs_store.h"
+#include "lcm_key_provider.h"
 
 static const char *TAG = "github_update";
 
@@ -57,7 +58,7 @@ static const char *TAG = "github_update";
 
 #define INSTALLED_VER_MAX_LEN 32
 #define OTA_SIG_MAGIC 0x4C434D53UL
-#define OTA_SIG_VERSION 1U
+#define OTA_SIG_VERSION 2U
 #define OTA_SIG_ALGO_ECDSA_P256_SHA256 1U
 #define OTA_SIG_MAX_LEN 512U
 #define INSTALLED_LABEL_MAX_LEN (ESP_PARTITION_LABEL_MAX_LEN + 1)
@@ -80,6 +81,8 @@ static const char *OTA_REASON_INVALID_IMAGE_LENGTH = "invalid_image_length";
 static const char *OTA_REASON_PARTITION_UNAVAILABLE = "partition_unavailable";
 static const char *OTA_REASON_BOOT_PARTITION_SET_FAILURE = "boot_partition_set_failure";
 static const char *OTA_REASON_HTTP_FAILURE = "http_failure";
+static const char *OTA_REASON_TARGET_MISMATCH = "target_mismatch";
+static const char *OTA_REASON_INCOMPLETE_PACKAGE = "update_package_incomplete";
 
 static const char *ota_state_to_str(ota_state_t state) {
     switch (state) {
@@ -793,21 +796,56 @@ static esp_err_t partition_sha256(const esp_partition_t *part, uint32_t len, uin
     return ESP_OK;
 }
 
+
+
+static uint16_t lcm_current_target_id(void) {
+#if CONFIG_IDF_TARGET_ESP32
+    return 0x0001;
+#elif CONFIG_IDF_TARGET_ESP32C2
+    return 0x0002;
+#elif CONFIG_IDF_TARGET_ESP32C3
+    return 0x0003;
+#elif CONFIG_IDF_TARGET_ESP32S2
+    return 0x0004;
+#elif CONFIG_IDF_TARGET_ESP32S3
+    return 0x0005;
+#elif CONFIG_IDF_TARGET_ESP32C5
+    return 0x0006;
+#elif CONFIG_IDF_TARGET_ESP32C6
+    return 0x0007;
+#else
+    return 0xFFFF;
+#endif
+}
+
+static const char *lcm_current_target_name(void) {
+#if CONFIG_IDF_TARGET_ESP32
+    return "esp32";
+#elif CONFIG_IDF_TARGET_ESP32C2
+    return "esp32c2";
+#elif CONFIG_IDF_TARGET_ESP32C3
+    return "esp32c3";
+#elif CONFIG_IDF_TARGET_ESP32S2
+    return "esp32s2";
+#elif CONFIG_IDF_TARGET_ESP32S3
+    return "esp32s3";
+#elif CONFIG_IDF_TARGET_ESP32C5
+    return "esp32c5";
+#elif CONFIG_IDF_TARGET_ESP32C6
+    return "esp32c6";
+#else
+    return "unknown";
+#endif
+}
 typedef struct __attribute__((packed)) {
     uint32_t magic;
     uint8_t version;
     uint8_t algorithm;
-    uint16_t reserved;
+    uint16_t target_id;
     uint32_t firmware_length;
     uint8_t firmware_hash[32];
     uint16_t signature_length;
 } ota_sig_header_t;
-
-static const char OTA_PUBLIC_KEY_PEM[] =
-"-----BEGIN PUBLIC KEY-----\n"
-"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECoIqacNbCn1oWreXsb2QTz6c+hOj\n"
-"ezXGuO01nfuVl/+sH2iB8bvkGnwW+f14lzqsQQ6H8DMxIRJCNjGMNqrYjg==\n"
-"-----END PUBLIC KEY-----\n";
 
 static esp_err_t verify_signature_blob(const uint8_t *sig_blob, size_t sig_len,
                                        uint32_t image_len, const uint8_t image_hash[32]) {
@@ -828,6 +866,13 @@ static esp_err_t verify_signature_blob(const uint8_t *sig_blob, size_t sig_len,
     if (header->algorithm != OTA_SIG_ALGO_ECDSA_P256_SHA256) {
         ESP_LOGE(TAG, "Unsupported signature algorithm id: %u", (unsigned)header->algorithm);
         return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    const uint16_t expected_target = lcm_current_target_id();
+    if (header->target_id != expected_target) {
+        ESP_LOGE(TAG, "Firmware target does not match device (sig target=0x%04x, device=%s/0x%04x)",
+                 (unsigned)header->target_id, lcm_current_target_name(), (unsigned)expected_target);
+        return ESP_ERR_INVALID_ARG;
     }
 
     if (header->firmware_length != image_len) {
@@ -853,8 +898,8 @@ static esp_err_t verify_signature_blob(const uint8_t *sig_blob, size_t sig_len,
     mbedtls_pk_init(&pk);
 
     int parse_res = mbedtls_pk_parse_public_key(&pk,
-            (const unsigned char *)OTA_PUBLIC_KEY_PEM,
-            strlen(OTA_PUBLIC_KEY_PEM) + 1);
+            (const unsigned char *)lcm_trusted_public_key_pem(),
+            strlen(lcm_trusted_public_key_pem()) + 1);
     if (parse_res != 0) {
         ESP_LOGE(TAG, "Public key parse failed: -0x%04x", -parse_res);
         mbedtls_pk_free(&pk);
@@ -871,7 +916,7 @@ static esp_err_t verify_signature_blob(const uint8_t *sig_blob, size_t sig_len,
         return ESP_ERR_INVALID_CRC;
     }
 
-    ESP_LOGI(TAG, "Cryptographic signature verified");
+    ESP_LOGI(TAG, "Cryptographic signature verified (mode=%s)", lcm_trusted_publisher_mode());
     return ESP_OK;
 }
 
@@ -948,9 +993,15 @@ esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url,
 
     ret = verify_signature_blob(sig, sig_len, meta.image_len, actual);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Signature validation failed: %s", esp_err_to_name(ret));
-        failure_reason = OTA_REASON_INVALID_SIGNATURE;
-        (void)ota_persist_state(OTA_STATE_FAILED, ret, NULL, release_version, NULL, OTA_REASON_INVALID_SIGNATURE);
+        if (ret == ESP_ERR_INVALID_ARG) {
+            ESP_LOGE(TAG, "firmware target does not match device");
+            failure_reason = OTA_REASON_TARGET_MISMATCH;
+            (void)ota_persist_state(OTA_STATE_FAILED, ret, NULL, release_version, NULL, OTA_REASON_TARGET_MISMATCH);
+        } else {
+            ESP_LOGE(TAG, "firmware not signed by trusted publisher");
+            failure_reason = OTA_REASON_INVALID_SIGNATURE;
+            (void)ota_persist_state(OTA_STATE_FAILED, ret, NULL, release_version, NULL, OTA_REASON_INVALID_SIGNATURE);
+        }
         goto cleanup;
     }
     led_blinking_stop();
@@ -1004,7 +1055,24 @@ cleanup:
 }
 
 esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
+    (void)prerelease;
     (void)ota_persist_state(OTA_STATE_CHECKING_RELEASE, ESP_OK, repo, NULL, NULL, OTA_REASON_NONE);
+
+    if (!repo || repo[0] == '\0') {
+        ESP_LOGE(TAG, "update source is empty");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (strncmp(repo, "http://", 7) == 0 || strncmp(repo, "https://", 8) == 0) {
+        char fw_url[384];
+        char sig_url[384];
+        snprintf(fw_url, sizeof(fw_url), "%s%smain.bin", repo, repo[strlen(repo)-1] == '/' ? "" : "/");
+        snprintf(sig_url, sizeof(sig_url), "%s%smain.bin.sig", repo, repo[strlen(repo)-1] == '/' ? "" : "/");
+        ESP_LOGI(TAG, "Using direct update source %s", repo);
+        return github_update_from_urls(fw_url, sig_url, NULL);
+    }
+
+    // GitHub repository mode (owner/repo)
     char api[256];
     snprintf(api, sizeof(api), "https://api.github.com/repos/%s/releases%s", repo,
              prerelease ? "?per_page=5" : "/latest");
@@ -1242,7 +1310,7 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
             else if (!strcmp(name->valuestring, "main.bin.sig")) sig = url->valuestring;
         }
     }
-    if (!fw || !sig) { cJSON_Delete(json); ESP_LOGE(TAG, "Missing assets"); (void)ota_persist_state(OTA_STATE_FAILED, ESP_FAIL, repo, sanitized_version, NULL, OTA_REASON_MISSING_ASSET); return ESP_FAIL; }
+    if (!fw || !sig) { cJSON_Delete(json); ESP_LOGE(TAG, "Update package incomplete: missing main.bin or main.bin.sig"); (void)ota_persist_state(OTA_STATE_FAILED, ESP_FAIL, repo, sanitized_version, NULL, OTA_REASON_INCOMPLETE_PACKAGE); return ESP_FAIL; }
     ESP_LOGD(TAG, "Firmware URL: %s", fw);
     ESP_LOGD(TAG, "Signature URL: %s", sig);
     ESP_LOGI(TAG, "Release %s selected", cJSON_IsString(tag)?tag->valuestring:"?");

--- a/main/include/github_update.h
+++ b/main/include/github_update.h
@@ -10,3 +10,14 @@ bool load_led_config(bool *enabled, int *gpio, bool *active_high);
 esp_err_t github_update_if_needed(const char *repo, bool prerelease);
 esp_err_t github_update_from_urls(const char *fw_url, const char *sig_url,
                                   const char *release_version);
+
+// Reserved for future manifest.json support.
+typedef struct {
+    const char *project;
+    const char *version;
+    const char *chip;
+    const char *firmware_path;
+    const char *signature_path;
+    const char *signer_id;
+    const char *minimum_lcm_version;
+} lcm_manifest_descriptor_t;

--- a/main/include/lcm_key_provider.h
+++ b/main/include/lcm_key_provider.h
@@ -1,0 +1,4 @@
+#pragma once
+
+const char *lcm_trusted_public_key_pem(void);
+const char *lcm_trusted_publisher_mode(void);

--- a/main/lcm_key_provider.c
+++ b/main/lcm_key_provider.c
@@ -1,0 +1,31 @@
+#include "lcm_key_provider.h"
+
+#include "official_public_key.h"
+
+#if CONFIG_LCM_PUBLISHER_MODE_CUSTOM
+#if defined(__has_include)
+#if __has_include("custom_public_key.h")
+#include "custom_public_key.h"
+#else
+#error "CONFIG_LCM_PUBLISHER_MODE_CUSTOM requires keys/custom_public_key.h"
+#endif
+#else
+#include "custom_public_key.h"
+#endif
+#endif
+
+const char *lcm_trusted_public_key_pem(void) {
+#if CONFIG_LCM_PUBLISHER_MODE_CUSTOM
+    return LCM_CUSTOM_PUBLIC_KEY_PEM;
+#else
+    return LCM_OFFICIAL_PUBLIC_KEY_PEM;
+#endif
+}
+
+const char *lcm_trusted_publisher_mode(void) {
+#if CONFIG_LCM_PUBLISHER_MODE_CUSTOM
+    return "Custom";
+#else
+    return "Official";
+#endif
+}

--- a/main/main.c
+++ b/main/main.c
@@ -35,6 +35,7 @@
 #include <soc/soc_caps.h>
 #include <inttypes.h>
 #include "github_update.h"
+#include "lcm_key_provider.h"
 #include "led_indicator.h"
 #include "lifecycle_manager.h"
 #include "lifecycle_restart_counter.h"
@@ -280,6 +281,7 @@ static void lifecycle_factory_reset_and_reboot(void) {
 
 void app_main(void) {
     ESP_LOGI(TAG, "Application start");
+    ESP_LOGI(TAG, "LCM publisher mode: %s", lcm_trusted_publisher_mode());
     esp_err_t err = nvs_flash_init();
     if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_LOGW(TAG, "NVS init requires recovery (%s), erasing NVS partition",

--- a/scripts/build_official_targets.sh
+++ b/scripts/build_official_targets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGETS=(esp32 esp32c2 esp32c3)
+OUT_DIR="${1:-dist}"
+mkdir -p "$OUT_DIR"
+
+for target in "${TARGETS[@]}"; do
+  echo "==> Building $target"
+  idf.py set-target "$target"
+  idf.py build
+  cp build/main.bin "$OUT_DIR/lcm-${target}.bin"
+  cp build/bootloader/bootloader.bin "$OUT_DIR/lcm-${target}-bootloader.bin"
+  cp build/partition_table/partition-table.bin "$OUT_DIR/lcm-${target}-partition-table.bin"
+done
+
+echo "Artifacts written to $OUT_DIR"

--- a/scripts/generate_keys.sh
+++ b/scripts/generate_keys.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR="${1:-keys/private}"
+BASE_NAME="${2:-publisher}"
+
+mkdir -p "$OUT_DIR"
+PRIVATE_KEY="$OUT_DIR/${BASE_NAME}_private.pem"
+PUBLIC_KEY="$OUT_DIR/${BASE_NAME}_public.pem"
+
+openssl ecparam -name prime256v1 -genkey -noout -out "$PRIVATE_KEY"
+openssl ec -in "$PRIVATE_KEY" -pubout -out "$PUBLIC_KEY"
+
+chmod 600 "$PRIVATE_KEY"
+
+echo "Generated private key: $PRIVATE_KEY"
+echo "Generated public key : $PUBLIC_KEY"
+echo "Keep the private key secret and out of git."

--- a/scripts/sign_firmware.sh
+++ b/scripts/sign_firmware.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <main.bin|build_dir> <private_key.pem> [target]"
+  exit 1
+fi
+
+TARGET_PATH="$1"
+PRIVATE_KEY_PATH="$2"
+TARGET_NAME="${3:-esp32}"
+
+case "$TARGET_NAME" in
+  esp32) TARGET_ID=1 ;;
+  esp32c2) TARGET_ID=2 ;;
+  esp32c3) TARGET_ID=3 ;;
+  esp32s2) TARGET_ID=4 ;;
+  esp32s3) TARGET_ID=5 ;;
+  esp32c5) TARGET_ID=6 ;;
+  esp32c6) TARGET_ID=7 ;;
+  *) echo "Unsupported target '$TARGET_NAME'"; exit 1 ;;
+esac
+
+if [[ -d "$TARGET_PATH" ]]; then
+  TARGET_PATH="${TARGET_PATH%/}/main.bin"
+fi
+
+if [[ ! -f "$TARGET_PATH" ]]; then
+  echo "Firmware image not found: $TARGET_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PRIVATE_KEY_PATH" ]]; then
+  echo "Private key not found: $PRIVATE_KEY_PATH" >&2
+  exit 1
+fi
+
+SIGNATURE_PATH="$TARGET_PATH.sig"
+TMP_HASH="$(mktemp)"
+TMP_DER="$(mktemp)"
+trap 'rm -f "$TMP_HASH" "$TMP_DER"' EXIT
+
+openssl dgst -sha256 -binary -out "$TMP_HASH" "$TARGET_PATH"
+openssl dgst -sha256 -sign "$PRIVATE_KEY_PATH" -out "$TMP_DER" "$TARGET_PATH"
+
+python3 - "$TARGET_PATH" "$TMP_HASH" "$TMP_DER" "$SIGNATURE_PATH" "$TARGET_ID" <<'PY'
+import os
+import struct
+import sys
+
+firmware_path, hash_path, sig_der_path, output_path, target_id = sys.argv[1:6]
+firmware_len = os.path.getsize(firmware_path)
+firmware_hash = open(hash_path, 'rb').read()
+signature_der = open(sig_der_path, 'rb').read()
+
+MAGIC = 0x4C434D53  # LCMS
+VERSION = 2
+ALGORITHM = 1  # ECDSA P-256 SHA-256
+TARGET_ID = int(target_id)
+
+header = struct.pack('<IBBHI32sH', MAGIC, VERSION, ALGORITHM, TARGET_ID,
+                     firmware_len, firmware_hash, len(signature_der))
+with open(output_path, 'wb') as f:
+    f.write(header)
+    f.write(signature_der)
+
+print(f"Wrote {output_path} ({len(header) + len(signature_der)} bytes, target_id={TARGET_ID})")
+PY

--- a/tests/test_signature_and_repo.py
+++ b/tests/test_signature_and_repo.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 
 MAGIC = 0x4C434D53
-VERSION = 1
+VERSION = 2
 ALGO = 1
 HEADER_FMT = '<IBBHI32sH'
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
@@ -84,6 +84,8 @@ def required_ota_failure_reasons():
         'partition_unavailable',
         'boot_partition_set_failure',
         'http_failure',
+        'target_mismatch',
+        'update_package_incomplete',
     }
 
 
@@ -100,7 +102,7 @@ def validate_sig_blob(blob: bytes, image: bytes):
     if len(blob) < HEADER_SIZE:
         return False, 'too_short'
 
-    magic, version, algo, _reserved, fw_len, fw_hash, sig_len = struct.unpack(HEADER_FMT, blob[:HEADER_SIZE])
+    magic, version, algo, _target_id, fw_len, fw_hash, sig_len = struct.unpack(HEADER_FMT, blob[:HEADER_SIZE])
     if magic != MAGIC:
         return False, 'bad_magic'
     if version != VERSION:
@@ -240,7 +242,7 @@ class OtaStateMachineTests(unittest.TestCase):
         reasons = required_ota_failure_reasons()
         self.assertIn('invalid_signature', reasons)
         self.assertIn('partition_unavailable', reasons)
-        self.assertEqual(len(reasons), 7)
+        self.assertEqual(len(reasons), 9)
 
 
 class PartitionLayoutTests(unittest.TestCase):
@@ -320,6 +322,7 @@ class SourceHardeningTests(unittest.TestCase):
         src = self._github_update_source()
         self.assertIn('const char *failure_reason = OTA_REASON_HTTP_FAILURE;', src)
         self.assertIn('failure_reason = OTA_REASON_INVALID_SIGNATURE;', src)
+        self.assertIn('failure_reason = OTA_REASON_TARGET_MISMATCH;', src)
         self.assertIn('failure_reason = OTA_REASON_INVALID_IMAGE_LENGTH;', src)
         self.assertIn('ota_persist_state(OTA_STATE_FAILED, ret, NULL, release_version, NULL, failure_reason);', src)
 


### PR DESCRIPTION
### Motivation
- Prevent wrong-target firmware installation and support both official and custom publisher trust models by embedding a target identifier in signature blobs and selecting a trust anchor at build-time.
- Provide easy local tooling for key generation, signing, and multi-target builds and make end-user workflows simpler and clearer in the docs.

### Description
- Add a configurable publisher mode via Kconfig (`LCM_PUBLISHER_MODE`) and implement a `lcm_key_provider` to expose the selected public key and mode at runtime.
- Bump the OTA signature format to version `2` and include a `target_id` in the signature header; update verification logic in `main/github_update.c` to validate target, hash, length and use the `lcm_key_provider` public key.
- Replace inline signature generator with `scripts/sign_firmware.sh` and add `scripts/generate_keys.sh` and `scripts/build_official_targets.sh`, update `generate_sig.sh` to call the new signer, and update CI to use `./scripts/sign_firmware.sh` and include `esp32c3` in the cross-target matrix.
- Add key artifacts and guidance (`keys/official_public_key.h`, `keys/custom_public_key.example.h`, `keys/README.md`), update `CMakeLists.txt` to include keys and `lcm_key_provider.c`, update docs (`README.md`, `enduser.md`) for official/custom modes and multi-target release workflows, extend `.gitignore` to exclude local key material, and update tests (`tests/test_signature_and_repo.py`) to reflect the new signature format and failure reasons.

### Testing
- Ran the unit test suite with `python3 -m unittest discover -s tests -v`, which includes `tests/test_signature_and_repo.py`, and the tests completed successfully.
- Updated unit tests validate the new signature header format (`VERSION = 2`), the additional failure reasons, and source hardening checks, and these tests passed under the local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d217a48c34832189bf953ecc5055cf)