### PR TITLE
Handle missing NVS 'wifi_cfg' namespace in nvs_load_wifi

### DIFF
--- a/examples/led/main/esp32-lcm.c
+++ b/examples/led/main/esp32-lcm.c
@@ -118,6 +118,10 @@ static esp_err_t nvs_load_wifi(char **out_ssid, char **out_pass) {
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open("wifi_cfg", NVS_READONLY, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(WIFI_TAG, "NVS namespace 'wifi_cfg' not found; provisioning required");
+        return err;
+    }
     if (err != ESP_OK) {
         ESP_LOGE(WIFI_TAG, "NVS open failed for namespace 'wifi_cfg': %s", esp_err_to_name(err));
         return err;


### PR DESCRIPTION
### Motivation
- Avoid noisy errors and fail gracefully when the NVS namespace `wifi_cfg` is not present (indicating provisioning is required) by explicitly handling that case in `nvs_load_wifi`.

### Description
- Add an explicit check after `nvs_open("wifi_cfg")` to detect `ESP_ERR_NVS_NOT_FOUND`, log a warning, and return the error instead of proceeding.

### Testing
- Built the example with `idf.py build` after the change and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d114290c8321bcae17b97ca8045e)