### PR TITLE
Handle missing/legacy NVS entries and relax NVS warning conditions

### DIFF
--- a/examples/led/main/esp32-lcm.c
+++ b/examples/led/main/esp32-lcm.c
@@ -118,6 +118,10 @@ static esp_err_t nvs_load_wifi(char **out_ssid, char **out_pass) {
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open("wifi_cfg", NVS_READONLY, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(WIFI_TAG, "NVS namespace 'wifi_cfg' not found; provisioning required");
+        return err;
+    }
     if (err != ESP_OK) {
         ESP_LOGE(WIFI_TAG, "NVS open failed for namespace 'wifi_cfg': %s", esp_err_to_name(err));
         return err;

--- a/main/github_update.c
+++ b/main/github_update.c
@@ -179,6 +179,8 @@ static esp_err_t ota_persist_state(ota_state_t state, esp_err_t last_error,
             nvs_store_close(h);
             return ESP_ERR_INVALID_STATE;
         }
+    } else if (current_err == ESP_ERR_NVS_INVALID_LENGTH) {
+        ESP_LOGW(TAG, "Ignoring legacy/invalid OTA state value and overwriting it");
     } else if (current_err != ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGW(TAG, "Failed to load current OTA state: %s", esp_err_to_name(current_err));
     }

--- a/main/nvs_store.c
+++ b/main/nvs_store.c
@@ -43,7 +43,7 @@ esp_err_t nvs_store_open_ro(const char *ns, nvs_handle_t *out_handle) {
         return ESP_ERR_INVALID_ARG;
     }
     esp_err_t err = nvs_open(ns, NVS_READONLY, out_handle);
-    if (err != ESP_OK) {
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGW(TAG, "nvs_open(ro:%s) failed: %s", ns, esp_err_to_name(err));
     }
     return err;
@@ -100,7 +100,7 @@ esp_err_t nvs_store_get_str(nvs_handle_t handle, const char *key, char *out_valu
         return ESP_ERR_INVALID_ARG;
     }
     esp_err_t err = nvs_get_str(handle, key, out_value, length);
-    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND && err != ESP_ERR_NVS_INVALID_LENGTH) {
         ESP_LOGW(TAG, "nvs_get_str(%s) failed: %s", key, esp_err_to_name(err));
     }
     return err;


### PR DESCRIPTION
### Motivation

- Reduce noisy warnings and handle absent or legacy NVS values gracefully to improve provisioning and OTA robustness.
- Allow OTA state to be overwritten when an old/invalid stored value exists instead of failing the transition.
- Provide clearer behavior when the `wifi_cfg` namespace is not present during Wi‑Fi provisioning.

### Description

- In `examples/led/main/esp32-lcm.c` log a warning and return when the `wifi_cfg` NVS namespace is not found in `nvs_load_wifi` by checking for `ESP_ERR_NVS_NOT_FOUND` and returning early.
- In `main/github_update.c` treat `ESP_ERR_NVS_INVALID_LENGTH` from loading the current OTA state as a benign/legacy value and overwrite it instead of rejecting the transition.
- In `main/nvs_store.c` suppress warnings from `nvs_store_open_ro` when the namespace is missing by not logging for `ESP_ERR_NVS_NOT_FOUND`, and suppress warnings from `nvs_store_get_str` when `ESP_ERR_NVS_INVALID_LENGTH` is returned so legacy/invalid-length strings are tolerated.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d114290c8321bcae17b97ca8045e)