### PR TITLE
Improve NVS robustness: handle missing namespaces and legacy string lengths; enlarge OTA state buffer

### DIFF
--- a/examples/led/main/esp32-lcm.c
+++ b/examples/led/main/esp32-lcm.c
@@ -118,6 +118,10 @@ static esp_err_t nvs_load_wifi(char **out_ssid, char **out_pass) {
 
     nvs_handle_t handle;
     esp_err_t err = nvs_open("wifi_cfg", NVS_READONLY, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(WIFI_TAG, "NVS namespace 'wifi_cfg' not found; provisioning required");
+        return err;
+    }
     if (err != ESP_OK) {
         ESP_LOGE(WIFI_TAG, "NVS open failed for namespace 'wifi_cfg': %s", esp_err_to_name(err));
         return err;

--- a/main/github_update.c
+++ b/main/github_update.c
@@ -167,7 +167,7 @@ static esp_err_t ota_persist_state(ota_state_t state, esp_err_t last_error,
         return err;
     }
 
-    char current_state_str[16];
+    char current_state_str[32];
     size_t current_len = sizeof(current_state_str);
     esp_err_t current_err = nvs_store_get_str(h, NVS_KEY_OTA_STATE, current_state_str, &current_len);
     if (current_err == ESP_OK) {
@@ -179,6 +179,8 @@ static esp_err_t ota_persist_state(ota_state_t state, esp_err_t last_error,
             nvs_store_close(h);
             return ESP_ERR_INVALID_STATE;
         }
+    } else if (current_err == ESP_ERR_NVS_INVALID_LENGTH) {
+        ESP_LOGW(TAG, "Ignoring legacy/invalid OTA state value and overwriting it");
     } else if (current_err != ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGW(TAG, "Failed to load current OTA state: %s", esp_err_to_name(current_err));
     }

--- a/main/nvs_store.c
+++ b/main/nvs_store.c
@@ -43,7 +43,7 @@ esp_err_t nvs_store_open_ro(const char *ns, nvs_handle_t *out_handle) {
         return ESP_ERR_INVALID_ARG;
     }
     esp_err_t err = nvs_open(ns, NVS_READONLY, out_handle);
-    if (err != ESP_OK) {
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
         ESP_LOGW(TAG, "nvs_open(ro:%s) failed: %s", ns, esp_err_to_name(err));
     }
     return err;
@@ -100,7 +100,7 @@ esp_err_t nvs_store_get_str(nvs_handle_t handle, const char *key, char *out_valu
         return ESP_ERR_INVALID_ARG;
     }
     esp_err_t err = nvs_get_str(handle, key, out_value, length);
-    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND && err != ESP_ERR_NVS_INVALID_LENGTH) {
         ESP_LOGW(TAG, "nvs_get_str(%s) failed: %s", key, esp_err_to_name(err));
     }
     return err;


### PR DESCRIPTION
### Motivation

- Reduce noisy warnings and hard failures when NVS namespaces or legacy/invalid string values are present in flash.
- Ensure OTA state persistence can tolerate longer or legacy values and avoid rejected transitions due to invalid stored data.

### Description

- Add explicit handling in `examples/led/main/esp32-lcm.c` to detect `ESP_ERR_NVS_NOT_FOUND` for the `wifi_cfg` namespace and log a clear provisioning-required warning before returning the error.
- Increase the OTA state buffer from 16 to 32 bytes in `main/github_update.c` to accommodate longer state strings and avoid truncation.
- Treat `ESP_ERR_NVS_INVALID_LENGTH` as a tolerated case when loading the current OTA state and log a warning that the legacy/invalid value will be overwritten in `main/github_update.c`.
- Suppress benign warnings in `main/nvs_store.c` by not warning for `ESP_ERR_NVS_NOT_FOUND` in `nvs_store_open_ro` and by not warning for `ESP_ERR_NVS_INVALID_LENGTH` in `nvs_store_get_str`.

### Testing

- Performed a local firmware build using the ESP-IDF build workflow (`idf.py build`) for the main application and examples, and the build completed successfully.
- No automated unit tests were changed, and existing build-time checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d114290c8321bcae17b97ca8045e)