### PR TITLE
Update partition table: enlarge app partitions and adjust OTA offsets

### DIFF
--- a/partitions.csv
+++ b/partitions.csv
@@ -1,8 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
-nvs,      data, nvs,     0x9000,  0x5000,
-otadata,  data, ota,     0xe000,  0x2000,
-nvs_keys, data, nvs_keys,0x10000, 0x1000, encrypted
-phy_init, data, phy,     0x11000, 0x1000,
-factory,  app,  factory, 0x20000, 1M,
-ota_0,    app,  ota_0,   0x120000, 1M,
-ota_1,    app,  ota_1,   0x220000, 1M
+nvs,      data, nvs,      0x9000,   0x5000,
+otadata,  data, ota,      0xe000,   0x2000,
+nvs_keys, data, nvs_keys, 0x10000,  0x1000, encrypted
+phy_init, data, phy,      0x11000,  0x1000,
+factory,  app,  factory,  0x20000,  0x140000,
+ota_0,    app,  ota_0,    0x160000, 0x140000,
+ota_1,    app,  ota_1,    0x2A0000, 0x140000,


### PR DESCRIPTION
### Motivation
- Increase app and OTA partition sizes and update offsets to support larger firmware images and a revised flash layout.

### Description
- Change `factory`, `ota_0`, and `ota_1` partition sizes to `0x140000` and set offsets to `factory` at `0x20000`, `ota_0` at `0x160000`, and `ota_1` at `0x2A0000`, and normalize CSV spacing.

### Testing
- No automated tests were run for this partition table change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c2ebe49083219598b1f14891fc19)