### PR TITLE
Treat factory firmware as OTA bootstrap version

### DIFF
--- a/main/github_update.c
+++ b/main/github_update.c
@@ -61,6 +61,7 @@ static const char *TAG = "github_update";
 #define OTA_SIG_ALGO_ECDSA_P256_SHA256 1U
 #define OTA_SIG_MAX_LEN 512U
 #define INSTALLED_LABEL_MAX_LEN (ESP_PARTITION_LABEL_MAX_LEN + 1)
+#define FACTORY_BOOTSTRAP_VERSION "0.0.0"
 typedef enum {
     OTA_STATE_IDLE = 0,
     OTA_STATE_CHECKING_RELEASE,
@@ -241,6 +242,13 @@ static int cmp_version(int aMaj, int aMin, int aPat,
     if (aMaj != bMaj) return aMaj - bMaj;
     if (aMin != bMin) return aMin - bMin;
     return aPat - bPat;
+}
+
+static bool running_from_factory_partition(void) {
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    return running &&
+           running->type == ESP_PARTITION_TYPE_APP &&
+           running->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY;
 }
 
 static esp_err_t store_installed_version_if_needed(const char *version,
@@ -1040,12 +1048,24 @@ esp_err_t github_update_if_needed(const char *repo, bool prerelease) {
         }
     }
 
+    bool running_factory = running_from_factory_partition();
     const esp_app_desc_t *running_desc = esp_app_get_description();
     if (!curValid) {
-        curValid = parse_version(running_desc ? running_desc->version : NULL,
-                                 &curMaj, &curMin, &curPat);
-        if (!curValid) {
-            ESP_LOGE(TAG, "Invalid current firmware version, assuming 0.0.0");
+        if (running_factory) {
+            curMaj = 0;
+            curMin = 0;
+            curPat = 0;
+            curValid = true;
+            strlcpy(installed_version, FACTORY_BOOTSTRAP_VERSION, sizeof(installed_version));
+            ESP_LOGI(TAG,
+                     "No installed OTA firmware stored; using factory bootstrap version %s",
+                     FACTORY_BOOTSTRAP_VERSION);
+        } else {
+            curValid = parse_version(running_desc ? running_desc->version : NULL,
+                                     &curMaj, &curMin, &curPat);
+            if (!curValid) {
+                ESP_LOGE(TAG, "Invalid current firmware version, assuming 0.0.0");
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent factory-built LCM images with a higher `esp_app_desc` version from blocking early OTA app releases by treating a factory boot with no stored OTA metadata as version `0.0.0`.

### Description
- Add a `FACTORY_BOOTSTRAP_VERSION` constant set to `"0.0.0"` in `main/github_update.c`.
- Add `running_from_factory_partition()` to detect when the device is running the factory partition.
- When no `installed_ver` is stored and the running partition is factory, treat the current firmware as `0.0.0` by populating `installed_version` with `FACTORY_BOOTSTRAP_VERSION` and marking the version valid.
- Update logging to indicate the bootstrap behaviour so small app releases (e.g. `0.0.1`) are considered valid updates even if the factory image uses a higher project version.

### Testing
- Ran `git diff --check` with no issues detected (sanity check passed).
- Built the project with `idf.py build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb65169c5c83218737aa53bd778d6c)